### PR TITLE
Issue 74 fix fertility confusion

### DIFF
--- a/MOD/Witcher/localisation/W_traits.csv
+++ b/MOD/Witcher/localisation/W_traits.csv
@@ -109,9 +109,9 @@ veteran;Veteran;;;;;;;;;;;;;x
 veteran_desc;This character is veteran of many battles.;;;;;;;;;;;;;x
 raider;Raider;;;;;;;;;;;;;x
 raider_desc;This character has acquired much fame as a fearsome raider.;;;;;;;;;;;;;x
-fertile_nonhuman;Fertile;;;;;;;;;;;;;x
+fertile_nonhuman;Fertile Nonhuman;;;;;;;;;;;;;x
 fertile_nonhuman_desc;This nonhuman possesses the ability to have children.;;;;;;;;;;;;;x
-fertile_sorcerer;Fertile;;;;;;;;;;;;;x
+fertile_sorcerer;Fertile Sorcerer;;;;;;;;;;;;;x
 fertile_sorcerer_desc;This sorcerer is naturally able to reproduce or has overcome his inability to reproduce through other means.;;;;;;;;;;;;;x
 academic;Academic;;;;;;;;;;;;;x
 academic_desc;This character has continued his education in one of the famous academies of the world.;;;;;;;;;;;;;x


### PR DESCRIPTION
Proposed fix for Issue #74 

By making it more explicit it now becomes clear to the player which of the two fertile traits is being referenced, for example in the "Cure Infidelity" ambition.

Seems to work (see screenshots below). I also did some character searches to see if it posed any problems.  A search for "fertile" showed me a bunch of elven characters with the "Fertile Nonhuman" trait, which is good. A search for "nonhuman" showed me the same bunch of elves, which makes sense.
 A search for "fertile sorcerer" showed me only Francesca, since she has both "Fertile Nonhuman" and "Sorcerer" traits.  This matches the behavior before, when fertile_nonhuman was just called "Fertile".

![bug01-fertile-nonhuman](https://user-images.githubusercontent.com/39809872/40870362-a60b6110-65fb-11e8-8811-1c5f37e37981.png)
![bug01-fertile-sorcerer](https://user-images.githubusercontent.com/39809872/40870363-a8893034-65fb-11e8-9cd1-3f6a55a0a0ec.png)
