### PR TITLE
Bug/issue 86 religious building name flickers

### DIFF
--- a/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
+++ b/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
@@ -2398,115 +2398,24 @@ defined_text = {
 defined_text = {
 	name = GetHouseOfWorship # Returns a suitable name for the house of worship of your religion (WIP)
 
-	text = {
-		localisation_key = GetHouseOfWorship_Christian
-		trigger = { religion_group = christian }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Muslim
-		trigger = { religion_group = muslim }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Pagan
-		trigger = { religion_group = pagan_group }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Zoroastrian
-		trigger = { religion_group = zoroastrian_group }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Jewish
-		trigger = { religion_group = jewish_group }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Hindu
-		trigger = { religion = hindu }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Buddhist
-		trigger = { religion = buddhist }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Jain
-		trigger = { religion = jain }
-	}
-	text = {
-		localisation_key = GetHouseOfWorship_Taoist
-		trigger = { religion = taoist }
+	fallback_text = {
+		localisation_key = string_Temple
 	}
 }
 
 defined_text = {
 	name = GetHouseOfWorshipCap # Returns a suitable name for the house of worship of your religion (WIP)
 
-	text = {
-		localisation_key = string_Church
-		trigger = { religion_group = christian }
-	}
-	text = {
-		localisation_key = string_Mosque
-		trigger = { religion_group = muslim }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion_group = pagan_group }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion_group = zoroastrian_group }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion_group = jewish_group }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion = hindu }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion = buddhist }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion = jain }
-	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion = taoist }
-	}
 	fallback_text = {
 		localisation_key = string_Temple
 	}
 }
 
-
 defined_text = {
 	name = GetReligiousRite # Returns a suitable name for a common rite in the character's religion
 
-	text = {
-		localisation_key = String_mass
-		trigger = { religion_group = christian }
-	}
-	text = {
+	fallback_text = {
 		localisation_key = String_prayer
-		trigger = { religion_group = muslim }
-	}
-	text = {
-		localisation_key = String_worship
-		trigger = { religion_group = pagan_group }
-	}
-	text = {
-		localisation_key = String_worship
-		trigger = { religion_group = zoroastrian_group }
-	}
-	text = {
-		localisation_key = String_prayer
-		trigger = { religion_group = jewish_group }
-	}
-	text = {
-		localisation_key = String_prayer
-		trigger = { religion_group = indian_group }
 	}
 }
 

--- a/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
+++ b/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
@@ -1,0 +1,10827 @@
+#AVIALABLE CUSTOM LOCALISATION KEYS
+#When adding new custom loc keys, add them to the appropriate category (or add a new one) and describe them. Name the strings "String_X" where x is its content.
+# To not display anything, you can use 'localisation_key = ""'
+# To have the first valid text be used, rather than a random valid text, use "use_first_valid = yes"s
+
+#RELATIONSHIPS
+#GetRootRelation
+#GetSisterBrother
+#GetSeductressSeducer
+#GetManWomanPreference		Gets man/woman depending on character's sexual preferences
+#GetMenWomenPreference		gets men/women depending on character's sexual preferences
+
+#EDUCATION
+#GetEducationSubject
+#GetEducationRole
+#GetEducationTool
+#GetEducationalTopicPlural
+
+#CHARACTER JOBS/TITLES
+#GetActressActor
+#GetAscetic
+#GetQueenKing
+#GetPrincessPrince
+#GetBrideGroom
+#GetMasterMistressCap
+
+#CHARACTER "DESCRIPTIONS"
+#GetVice
+#GetFaceDescription
+#GetComplimentNoun
+#GetComplimentAdjective
+#GetInsultNoun
+#GetInsultAdjective
+#GetDisease
+#GetWesternZodiacSign		Gets the western astrological zodiac sign of character (based on birth date)
+
+#SOCIETIES
+#GetSocietyName
+#GetSocietyNameCap
+#GetDWReasonToJoin
+#GetDWDevil
+#GetDWDarkMagic
+#GetDWDemon
+#GetDWDemons
+#GetDWMagician
+#GetDWExpression
+#GetMission
+#GetMOGod
+#GetMOSaint
+#GetMOBuilding
+#GetMOCode
+#GetMOGreeting
+#GetMOFarewell
+#GetSRGreeting
+#GetSRFarewell
+#GetSRTrinketSymbol
+#GetHermesThriceBlessed
+#GetHermeticsRank
+#GetHermeticDebateSubject
+#GetSillyDebateSubject
+
+#RELIGION
+#GetHouseOfWorship 			Gets name for house of worship of character's religion (character)
+#GetReligiousRite 			Gets name for a common religious rite (character)
+#GetReligionWarrior
+#GetReligionWarriorPlural
+#GetReligiousPerson
+#GetTrueReligionGroupPersons
+#GetTrueReligionAdjective
+#GetTrueReligionAdherent
+#GetTrueReligionScriptureName
+#TrueReligion.GetHighGodName
+#GetTrueReligionPerson
+#GetArtifactSource			Gets name for bodypart artifact's source (saint, holy man, hero)
+#GetArtifactSourceCap
+#GetReligionAdherent
+
+#PLACES
+#GetCapitalHolding			Gets an appropriate noun describing a character's capital holding (character)
+#GetHolding 				Gets an appropriate noun to describe a holding (holding)
+#GetChamberOpening 			Gets door/tent opening for capital holding (character)
+#GetChamber 				Gets chamber/tent for capital holding (character)
+#GetReligionTempleName
+
+#WEATHER, TIME
+#GetWeatherAdjective
+#GetTemperature
+#GetSeason #WIP
+
+#CHINA
+#GetLongChineseEmperorName
+#GetMediumChineseEmperorName
+#GetShortChineseEmperorName
+#GetCouncillorLetterGreeting
+#GetRulerLetterGreeting
+#GetGovernorLetterGreeting
+#GetChineseLetterBlessing
+#GetChineseComplimentAdjective
+#GetChineseOffmapTributaryPrestigeCost
+#GetChineseForceOpenDemand
+#GetChineseForceOpenDemandChina
+
+#MISC
+#GetMatterOfImportance
+
+
+###RELATIONSHIPS###
+defined_text = {
+	name = GetRootRelation
+
+	text = {
+		localisation_key = GetRelation_Wife
+		trigger = {
+			is_female = yes
+			any_spouse = { character = ROOT }
+			NOT = { is_child_of = ROOT }
+			NOT = { any_child = { character = ROOT } }
+			sibling_of_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Husband
+		trigger = {
+			is_female = no
+			any_spouse = { character = ROOT }
+			NOT = { is_child_of = ROOT }
+			NOT = { any_child = { character = ROOT } }
+			sibling_of_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_MotherWife
+		trigger = {
+			is_female = yes
+			any_spouse = { character = ROOT }
+			any_child = { character = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_FatherHusband
+		trigger = {
+			is_female = no
+			any_spouse = { character = ROOT }
+			any_child = { character = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_DaughterWife
+		trigger = {
+			is_female = yes
+			any_spouse = { character = ROOT }
+			is_child_of = ROOT
+		}
+	}
+	text = {
+		localisation_key = GetRelation_SonHusband
+		trigger = {
+			is_female = no
+			any_spouse = { character = ROOT }
+			is_child_of = ROOT
+		}
+	}
+	text = {
+		localisation_key = GetRelation_SisterWife
+		trigger = {
+			is_female = yes
+			any_spouse = { character = ROOT }
+			sibling_of_root_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = GetRelation_BrotherHusband
+		trigger = {
+			is_female = no
+			any_spouse = { character = ROOT }
+			sibling_of_root_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Mother
+		trigger = {
+			is_female = yes
+			any_child = { character = ROOT }
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Father
+		trigger = {
+			is_female = no
+			any_child = { character = ROOT }
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Grandmother
+		trigger = {
+			is_female = yes
+			any_child = { any_child = { character = ROOT } }
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Grandfather
+		trigger = {
+			is_female = no
+			any_child = { any_child = { character = ROOT } }
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Daughter
+		trigger = {
+			is_female = yes
+			is_child_of = ROOT
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Son
+		trigger = {
+			is_female = no
+			is_child_of = ROOT
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Granddaughter
+		trigger = {
+			is_female = yes
+			grandchild_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Grandson
+		trigger = {
+			is_female = no
+			grandchild_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Sister
+		trigger = {
+			is_female = yes
+			sibling_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Brother
+		trigger = {
+			is_female = no
+			sibling_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Niece
+		trigger = {
+			is_female = yes
+			sibling_child_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Nephew
+		trigger = {
+			is_female = no
+			sibling_child_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Aunt
+		trigger = {
+			is_female = yes
+			parent_sibling_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Uncle
+		trigger = {
+			is_female = no
+			parent_sibling_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Cousin_Female
+		trigger = {
+			is_female = yes
+			sibling_in_law_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Cousin_Male
+		trigger = {
+			is_female = no
+			sibling_in_law_of_root_trigger = yes
+			NOT = { any_spouse = { character = ROOT } }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_SisterInLaw
+		trigger = {
+			is_female = yes
+			sibling_in_law_of_root_trigger = yes
+			NOT = { is_close_relative = ROOT }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_BrotherInLaw
+		trigger = {
+			is_female = no
+			sibling_in_law_of_root_trigger = yes
+			NOT = { is_close_relative = ROOT }
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_MotherInLaw
+		trigger = {
+			is_female = yes
+			relative_in_law_of_root_trigger = yes
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_FatherInLaw
+		trigger = {
+			is_female = no
+			relative_in_law_of_root_trigger = yes
+			relationship_with_root_trigger = no
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Rival_Male
+		trigger = {
+			is_female = no
+			is_rival = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Rival_Female
+		trigger = {
+			is_female = yes
+			is_rival = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Friend_Male
+		trigger = {
+			is_female = no
+			is_friend = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Friend_Female
+		trigger = {
+			is_female = yes
+			is_friend = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Lover_Male
+		trigger = {
+			is_female = no
+			is_lover = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Lover_Female
+		trigger = {
+			is_female = yes
+			is_lover = ROOT
+			NOT = { is_close_relative = ROOT }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Kinswoman
+		trigger = {
+			is_female = yes
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			dynasty = ROOT
+			NOT = { dynasty = none }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Kinsman
+		trigger = {
+			is_female = no
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			dynasty = ROOT
+			NOT = { dynasty = none }
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Liege_Male
+		trigger = {
+			is_female = no
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_liege_of = ROOT
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Liege_Female
+		trigger = {
+			is_female = yes
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_liege_of = ROOT
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Vassal_Male
+		trigger = {
+			is_female = no
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_landed = yes
+			liege = { character = ROOT }
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Vassal_Female
+		trigger = {
+			is_female = yes
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_landed = yes
+			liege = { character = ROOT }
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Courtier_Male
+		trigger = {
+			is_female = no
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_landed = no
+			liege = { character = ROOT }
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Courtier_Female
+		trigger = {
+			is_female = yes
+			relationship_with_root_trigger = no
+			family_of_root_trigger = no
+			is_landed = no
+			liege = { character = ROOT }
+			OR = {
+				NOT = { dynasty = ROOT }
+				dynasty = none
+			}
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Acquaintance 
+		trigger = { 
+			NOR = { 
+				relationship_with_root_trigger = yes
+				family_of_root_trigger = yes
+				liege = { character = ROOT }
+				is_liege_of = ROOT
+				AND = {
+					dynasty = ROOT
+					NOT = { dynasty = none }
+				}
+			} 
+		}
+	}
+	text = {
+		localisation_key = GetRelation_Concubine
+		weight_multiplier = { factor = 100 }
+		trigger = { 
+			is_consort = ROOT
+		}
+	}
+	fallback_text = {
+		localisation_key = String_root_relation_fallback #fallback, in case it fails to find relevant info
+	}
+}
+
+#The relationship This has to Root
+
+
+### Sister or Brother (not necessarily related)
+defined_text = {
+	name = GetSisterBrother
+
+	text = {
+		localisation_key = String_sister
+		trigger = {
+			is_female = yes
+		}
+	}
+	text = {
+		localisation_key = String_brother
+		trigger = {
+			is_female = no
+		}
+	}
+}
+
+defined_text = {
+	name = GetSisterBrotherCap
+
+	text = {
+		localisation_key = String_Sister
+		trigger = {
+			is_female = yes
+		}
+	}
+	text = {
+		localisation_key = String_Brother
+		trigger = {
+			is_female = no
+		}
+	}
+}
+
+defined_text = {
+	name = GetDaughterSon
+
+	text = {
+		localisation_key = String_daughter
+		trigger = {
+			is_female = yes
+		}
+	}
+	text = {
+		localisation_key = String_son
+		trigger = {
+			is_female = no
+		}
+	}
+}
+
+### Seductress or Seducer
+defined_text = {
+	name = GetSeductressSeducer
+
+	text = {
+		localisation_key = String_seductress
+		trigger = { is_female = yes }
+	}
+	text = {
+		localisation_key = String_seducer
+		trigger = { is_female = no }
+	}
+}
+
+### Seductress or Seducer
+defined_text = {
+	name = GetSeductressSeducerCap
+
+	text = {
+		localisation_key = String_Seductress
+		trigger = { is_female = yes }
+	}
+	text = {
+		localisation_key = String_Seducer
+		trigger = { is_female = no }
+	}
+}
+
+defined_text = {
+	name = GetManWomanPreference
+	text = {
+		localisation_key = String_man
+		trigger = { prefers_men_trigger = yes }
+	}
+	text = {
+		localisation_key = String_woman
+		trigger = { prefers_men_trigger = no }
+	}
+}
+
+defined_text = {
+	name = GetMenWomenPreference
+	text = {
+		localisation_key = String_men
+		trigger = { prefers_men_trigger = yes }
+	}
+	text = {
+		localisation_key = String_women
+		trigger = { prefers_men_trigger = no }
+	}
+}
+
+
+###EDUCATION###
+defined_text = {
+	name = GetEducationSubject
+
+	text = {
+		localisation_key = GetEducationSubject_Warfare
+		trigger = { has_education_martial_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationSubject_Diplomacy
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationSubject_Stewardship
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationSubject_Intrigue
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationSubject_Theology
+		trigger = { has_education_learning_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetEducationRole
+
+	text = {
+		localisation_key = GetEducationRole_Strategist
+		trigger = { has_education_martial_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationRole_Diplomat
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationRole_Steward
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationRole_Schemer
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = GetEducationRole_Theologian
+		trigger = { has_education_learning_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetEducationTool
+
+	text = {
+		localisation_key = String_war_table
+		trigger = { has_education_martial_trigger = yes }
+	}
+	text = {
+		localisation_key = String_correspondence
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = String_ledgers
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = String_maps
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = String_scrolls
+		trigger = { has_education_learning_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetEducationalTopicPlural
+
+	text = {
+		localisation_key = String_strategies
+		trigger = { has_education_martial_trigger = yes }
+	}
+	text = {
+		localisation_key = String_troop_compositions
+		trigger = { has_education_martial_trigger = yes }
+	}
+	text = {
+		localisation_key = String_diplomats
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = String_alliances
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = String_phrasings
+		trigger = { has_education_diplomacy_trigger = yes }
+	}
+	text = {
+		localisation_key = String_trade_routes
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = String_investment_opportunities
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = String_building_plans
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = String_tax_levels
+		trigger = { has_education_stewardship_trigger = yes }
+	}
+	text = {
+		localisation_key = String_poisons
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = String_spies
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = String_travel_routes
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = String_potential_accomplices
+		trigger = { has_education_intrigue_trigger = yes }
+	}
+	text = {
+		localisation_key = String_GetPriestName_plural
+		trigger = { has_education_learning_trigger = yes }
+	}
+	text = {
+		localisation_key = String_translations
+		trigger = { has_education_learning_trigger = yes }
+	}
+	text = {
+		localisation_key = String_doctrines
+		trigger = { has_education_learning_trigger = yes }
+	}
+	text = {
+		localisation_key = String_passages_from_GetScriptureName
+		trigger = { has_education_learning_trigger = yes }
+	}
+}
+
+###CHARACTER JOBS###
+defined_text = {
+	name = GetActressActor
+
+	text = {
+		trigger = { is_female = no }
+		localisation_key = Actor
+	}
+	text = {
+		trigger = { is_female = yes }
+		localisation_key = Actress
+	}	
+}
+
+defined_text = {
+	name = GetAscetic
+
+	text = {
+		trigger = { trait = monk }
+		localisation_key = String_monk
+	}
+	text = {
+		trigger = { trait = nun }
+		localisation_key = String_nun
+	}
+	text = {
+		trigger = { trait = muni }
+		localisation_key = String_muni
+	}
+	text = {
+		trigger = { trait = aryika }
+		localisation_key = String_aryika
+	}
+	text = {
+		trigger = { trait = bhikkhu }
+		localisation_key = String_bhikkhu
+	}
+	text = {
+		trigger = { trait = bhikkhuni }
+		localisation_key = String_bhikkhuni
+	}
+	text = {
+		trigger = { trait = sanyasi }
+		localisation_key = String_sanyasi
+	}
+	text = {
+		trigger = { trait = sanyasini }
+		localisation_key = String_sanyasini
+	}
+}
+
+defined_text = {
+	name = GetQueenKing
+
+	text = {
+		trigger = { is_female = yes }
+		localisation_key = String_Queen
+	}
+	text = {
+		trigger = { is_female = no }
+		localisation_key = String_King
+	}	
+}
+
+defined_text = {
+	name = GetPrincessPrince
+
+	text = {
+		trigger = { is_female = yes }
+		localisation_key = String_Princess
+	}
+	text = {
+		trigger = { is_female = no }
+		localisation_key = String_Prince
+	}	
+}
+
+defined_text = {
+	name = GetBrideGroom
+
+	text = {
+		trigger = { is_female = yes }
+		localisation_key = String_bride
+	}
+	text = {
+		trigger = { is_female = no }
+		localisation_key = String_groom
+	}	
+}
+
+defined_text = {
+	name = GetMasterMistressCap
+
+	text = {
+		trigger = { is_female = no }
+		localisation_key = String_Mistress
+	}
+	text = {
+		trigger = { is_female = yes }
+		localisation_key = String_Master
+	}	
+}
+
+###CHARACTER DESCRIPTIONS###
+defined_text = {
+	name = GetVice
+
+	text = {
+		trigger = { trait = lustful  }
+		localisation_key = String_Vice_lustful
+	}
+	text = {
+		trigger = { trait = gluttonous }
+		localisation_key = String_Vice_gluttonous
+	}
+	text = {
+		trigger = { trait = greedy }
+		localisation_key = String_Vice_greedy
+	}
+	text = {
+		trigger = { trait = slothful }
+		localisation_key = String_Vice_slothful
+	}
+	text = {
+		trigger = { trait = wroth }
+		localisation_key = String_Vice_wroth
+	}
+	text = {
+		trigger = { trait = envious }
+		localisation_key = String_Vice_envious
+	}
+	text = {
+		trigger = { trait = proud }
+		localisation_key = String_Vice_proud
+	}
+}
+
+defined_text = {
+	name = GetFaceDescription
+
+	text = {
+		trigger = { 
+			trait = fair 
+			is_female = yes
+			NOT = { trait = horse }
+		}
+		localisation_key = String_beautiful
+	}
+	text = {
+		trigger = { 
+			trait = fair 
+			is_female = no
+			NOT = { trait = horse }
+		}
+		localisation_key = String_handsome
+	}
+	text = {
+		trigger = { trait = ugly }
+		localisation_key = String_hideous
+	}
+	text = {
+		trigger = { trait = scarred }
+		localisation_key = String_scarred
+	}
+	text = {
+		trigger = { is_ill_trigger = yes }
+		localisation_key = String_sickly
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = disfigured
+				trait = blinded
+				trait = one_eyed
+				trait = leper
+			}
+		}
+		localisation_key = String_disfigured
+	}
+	text = {
+		trigger = { trait = harelip }
+		localisation_key = String_harelipped
+	}
+	text = {
+		trigger = { 
+			is_strong_trigger = yes 
+			NOT = { trait = horse }
+		}
+		localisation_key = String_strong_jawed
+	}
+	text = {
+		trigger = { is_weak_trigger = yes }
+		localisation_key = String_thin
+	}
+	text = {
+		trigger = { 
+			OR = {
+				trait = lunatic
+				trait = possessed
+				trait = rabies
+			}
+		}
+		localisation_key = String_crazed
+	}
+	text = {
+		trigger = { 
+			interesting_face_trigger = no
+			graphical_culture = norsegfx 
+		}
+		localisation_key = String_ruddy
+	}
+	text = {
+		trigger = { 
+			interesting_face_trigger = no
+			OR = {
+				graphical_culture = occitangfx 
+				graphical_culture = italiangfx 
+				graphical_culture = southerngfx
+				graphical_culture = byzantinegfx
+				graphical_culture = byzantinegfx
+				graphical_culture = easternslavicgfx
+				graphical_culture = byzantinegfx
+				graphical_culture = turkishgfx 
+				graphical_culture = cumangfx
+				graphical_culture = mongolgfx
+				graphical_culture = persiangfx
+			}
+		}
+		localisation_key = String_tanned
+	}
+	text = {
+		trigger = { 
+			interesting_face_trigger = no
+			OR = {
+				graphical_culture = arabicgfx
+				graphical_culture = andalusiangfx
+				graphical_culture = muslimgfx
+				graphical_culture = mesoamericangfx
+			}
+		}
+		localisation_key = String_bronzed
+	}
+	text = {
+		trigger = {
+			interesting_face_trigger = no 
+			OR = {
+				graphical_culture = africangfx
+				graphical_culture = westafricangfx
+			}
+		}
+		localisation_key = String_dark_skinned
+	}
+	text = {
+		trigger = { 
+			interesting_face_trigger = no
+			OR = {
+				graphical_culture = indiangfx
+				graphical_culture = southindiangfx
+			}
+		}
+		localisation_key = String_copper_skinned
+	}
+	text = {
+		trigger = { trait = horse }
+		localisation_key = String_long
+	}
+	text = {
+		weight_multiplier = { factor = 100 }
+		trigger = {
+			NOR = {
+				interesting_face_trigger = yes
+				graphical_culture = occitangfx 
+				graphical_culture = italiangfx
+				graphical_culture = southerngfx
+				graphical_culture = byzantinegfx
+				graphical_culture = byzantinegfx
+				graphical_culture = easternslavicgfx
+				graphical_culture = byzantinegfx
+				graphical_culture = turkishgfx 
+				graphical_culture = cumangfx
+				graphical_culture = mongolgfx
+				graphical_culture = persiangfx
+				graphical_culture = arabicgfx
+				graphical_culture = andalusiangfx
+				graphical_culture = muslimgfx
+				graphical_culture = mesoamericangfx
+				graphical_culture = africangfx
+				graphical_culture = westafricangfx
+				graphical_culture = indiangfx
+				graphical_culture = southindiangfx
+			}
+		}
+		localisation_key = String_pale
+	}
+}
+
+defined_text = {
+	name = GetComplimentAdjective
+	text = {
+		trigger = {
+			OR = {
+				trait = intricate_webweaver
+				trait = elusive_shadow
+				trait = fortune_builder
+				trait = midas_touched
+				trait = scholarly_theologian
+				trait = mastermind_theologian
+			}
+		}
+		localisation_key = COMPL_CLEVER
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = charismatic_negotiator
+				trait = grey_eminence
+			}
+		}
+		localisation_key = COMPL_ELOQUENT
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = fortune_builder
+				trait = midas_touched
+			}
+		}
+		localisation_key = COMPL_THRIFTY
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = scholarly_theologian
+				trait = mastermind_theologian
+			}
+		}
+		localisation_key = COMPL_LEARNED
+	}
+}
+
+defined_text = {
+	name = GetInsultAdjective
+	text = {
+		trigger = {
+			OR = {
+				trait = amateurish_plotter
+				trait = flamboyant_schemer
+				trait = intricate_webweaver
+				trait = elusive_shadow
+			}
+		}
+		localisation_key = INSULT_SCHEMING
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = naive_appeaser
+				trait = underhanded_rogue
+				trait = charismatic_negotiator
+				trait = grey_eminence
+			}
+		}
+		localisation_key = INSULT_TWOFACED
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = indulgent_wastrel
+				trait = thrifty_clerk
+				trait = charismatic_negotiator
+				trait = grey_eminence
+			}
+		}
+		localisation_key = INSULT_MISERLY
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = detached_priest
+				trait = martial_cleric
+				trait = scholarly_theologian
+				trait = mastermind_theologian
+			}
+		}
+		localisation_key = INSULT_DRIVELING
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = amateurish_plotter
+				trait = naive_appeaser
+				trait = indulgent_wastrel
+				trait = detached_priest
+			}
+		}
+		localisation_key = INSULT_STUPID
+	}
+	text = {
+		trigger = { trait = depressed }
+		localisation_key = INSULT_LUGUBRIOUS
+	}
+	text = {
+		trigger = { trait = depressed }
+		localisation_key = INSULT_LUGUBRIOUS
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_DEMENTED
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_CRAZED
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_CRAZY
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_DEMONIC
+	}
+	text = {
+		trigger = { 
+			OR = {
+				trait = syphilitic
+				trait = has_aztec_disease 
+			}
+		}
+		localisation_key = INSULT_DEMONIC
+	}
+	text = {
+		trigger = { trait = leper }
+		localisation_key = INSULT_UNCLEAN
+	}
+	text = {
+		trigger = { 
+			OR = {
+				trait = infirm
+			}
+		}
+		localisation_key = INSULT_CRIPPLE
+	}
+}
+
+defined_text = {
+	name = GetInsultNoun
+	text = {
+		trigger = { trait = depressed }
+		localisation_key = INSULT_LUGUBRIOUS
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_LUNATIC
+	}
+	text = {
+		trigger = { trait = lunatic }
+		localisation_key = INSULT_BAT
+	}
+	text = {
+		trigger = {
+			trait = possessed
+			is_female = no
+		}
+		localisation_key = INSULT_WARLOCK
+	}
+	text = {
+		trigger = {
+			trait = possessed
+			is_female = yes
+		}
+		localisation_key = INSULT_DEVIL_WOMAN
+	}
+	text = {
+		trigger = { trait = possessed }
+		localisation_key = INSULT_DEVIL
+	}
+	text = {
+		trigger = { trait = leper }
+		localisation_key = INSULT_LEPER
+	}
+	text = {
+		trigger = { 
+			OR = {
+				trait = maimed
+			}
+		}
+		localisation_key = INSULT_CRIPPLE
+	}
+}
+
+defined_text = {
+	name = GetDisease
+	text = {
+		trigger = { trait = ill }
+		localisation_key = String_fever
+	}
+	text = {
+		trigger = { trait = pneumonic }
+		localisation_key = string_pneumonia
+	}
+	text = {
+		trigger = { trait = syphilitic }
+		localisation_key = String_syphilis
+	}
+	text = {
+		trigger = { trait = leper }
+		localisation_key = String_leprocy
+	}
+	text = {
+		trigger = { trait = has_tuberculosis }
+		localisation_key = String_consumption
+	}
+	text = {
+		trigger = { trait = has_typhoid_fever }
+		localisation_key = String_slow_fever
+	}
+	text = {
+		trigger = { trait = has_typhus }
+		localisation_key = String_camp_fever
+	}
+	text = {
+		trigger = { trait = has_bubonic_plague }
+		localisation_key = String_the_Plague
+	}
+	text = {
+		trigger = { trait = has_measles }
+		localisation_key = String_measles
+	}
+	text = {
+		trigger = { trait = has_small_pox }
+		localisation_key = String_smallpox
+	}
+	text = {
+		trigger = { trait = has_aztec_disease }
+		localisation_key = String_syphilis
+	}
+	text = {
+		trigger = { trait = flu }
+		localisation_key = String_flu
+	}
+	text = {
+		trigger = { trait = dysentery }
+		localisation_key = String_dysentery
+	}
+	text = {
+		trigger = { trait = gout }
+		localisation_key = String_gout
+	}
+	text = {
+		trigger = { trait = food_poisoning }
+		localisation_key = String_food_poisoning
+	}
+	text = {
+		trigger = { trait = rabies }
+		localisation_key = String_rabies
+	}
+	text = {
+		trigger = { trait = dancing_plague }
+		localisation_key = String_dancing_plague
+	}
+	text = {
+		trigger = { trait = scurvy }
+		localisation_key = String_scurvy
+	}
+	text = {
+		trigger = { trait = cancer }
+		localisation_key = String_Cancer
+	}
+}
+
+###SOCIETIES###
+defined_text = {
+	name = GetSocietyName # Returns the name of target's society
+
+	text = {
+		localisation_key = String_the_Assassins
+		trigger = { society_member_of = the_assassins }
+	}
+	text = {
+		localisation_key = String_the_Satanists
+		trigger = { society_member_of = the_satanists }
+	}
+	text = {
+		localisation_key = String_the_Cold_Ones
+		trigger = { society_member_of = the_cold_ones }
+	}
+	text = {
+		localisation_key = String_the_Trollcrafters
+		trigger = { society_member_of = the_trollcrafters }
+	}
+	text = {
+		localisation_key = String_the_Cult_of_Kali_Purusha
+		trigger = { society_member_of = the_cult_of_kali }
+	}
+	text = {
+		localisation_key = String_the_Plaguebringers
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = String_the_Benedictine_Order
+		trigger = { society_member_of = monastic_order_benedictine }
+	}
+	text = {
+		localisation_key = String_the_Dominican_Order
+		trigger = { society_member_of = monastic_order_dominican }
+	}
+	text = {
+		localisation_key = String_the_Community_of_Saint_Basil
+		trigger = { society_member_of = monastic_order_orthodox }
+	}
+	text = {
+		localisation_key = String_the_Community_of_Saint_Abraham
+		trigger = { society_member_of = monastic_order_nestorian }
+	}
+	text = {
+		localisation_key = String_the_Community_of_Saint_Anthony
+		trigger = { society_member_of = monastic_order_monophysite }
+	}
+	text = {
+		localisation_key = String_the_Sravaka_Samgha
+		trigger = { society_member_of = monastic_order_jain }
+	}
+	text = {
+		localisation_key = String_the_Advaita_Matha
+		trigger = { society_member_of = monastic_order_hindu }
+	}
+	text = {
+		localisation_key = String_the_Savaka_Sangha
+		trigger = { society_member_of = monastic_order_buddhist }
+	}
+	text = {
+		localisation_key = hermetics
+		trigger = { society_member_of = hermetics }
+	}
+}
+
+defined_text = {
+	name = GetSocietyNameCap # Returns the name of target's society with inital Capital letter
+
+	text = {
+		localisation_key = the_assassins
+		trigger = { society_member_of = the_assassins }
+	}
+	text = {
+		localisation_key = the_satanists
+		trigger = { society_member_of = the_satanists }
+	}
+	text = {
+		localisation_key = the_cold_ones
+		trigger = { society_member_of = the_cold_ones }
+	}
+	text = {
+		localisation_key = the_trollcrafters
+		trigger = { society_member_of = the_trollcrafters }
+	}
+	text = {
+		localisation_key = the_cult_of_kali
+		trigger = { society_member_of = the_cult_of_kali }
+	}
+	text = {
+		localisation_key = the_plaguebringers
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = monastic_order_benedictine
+		trigger = { society_member_of = monastic_order_benedictine }
+	}
+	text = {
+		localisation_key = monastic_order_dominican
+		trigger = { society_member_of = monastic_order_dominican }
+	}
+	text = {
+		localisation_key = monastic_order_orthodox
+		trigger = { society_member_of = monastic_order_orthodox }
+	}
+	text = {
+		localisation_key = monastic_order_nestorian
+		trigger = { society_member_of = monastic_order_nestorian }
+	}
+	text = {
+		localisation_key = monastic_order_monophysite
+		trigger = { society_member_of = monastic_order_monophysite }
+	}
+	text = {
+		localisation_key = monastic_order_jain
+		trigger = { society_member_of = monastic_order_jain }
+	}
+	text = {
+		localisation_key = monastic_order_hindu
+		trigger = { society_member_of = monastic_order_hindu }
+	}
+	text = {
+		localisation_key = monastic_order_buddhist
+		trigger = { society_member_of = monastic_order_buddhist }
+	}
+	text = {
+		localisation_key = hermeticsCap
+		trigger = { society_member_of = hermetics }
+	}
+}
+
+
+defined_text = {
+	name = GetDWReasonToJoin # Returns a phrase along the lines of "cure my lover" or "help me win on the battlefield"
+
+	text = {
+		localisation_key = String_ill_lover
+		trigger = { has_character_flag = has_ill_lover_loc }
+	}
+	text = {
+		localisation_key = String_ill_spouse
+		trigger = { has_character_flag = has_ill_spouse_loc }
+	}
+	text = {
+		localisation_key = String_ill_child
+		trigger = { has_character_flag = has_ill_child_loc }
+	}
+	text = {
+		localisation_key = String_money_troubles
+		trigger = { has_character_flag = has_money_troubles_loc }
+	}
+	text = {
+		localisation_key = String_has_a_rival
+		trigger = { has_character_flag = has_a_rival_loc }
+	}
+	text = {
+		localisation_key = String_illness
+		trigger = { has_character_flag = has_some_illness_loc }
+	}
+	text = {
+		localisation_key = String_battle_luck
+		trigger = { has_character_flag = has_need_of_winning_battles_loc }
+	}
+	text = {
+		localisation_key = String_GetDWReasonToJoin_fallback
+		trigger = {
+			NOR = {
+				has_character_flag = has_ill_lover_loc
+				has_character_flag = has_ill_spouse_loc
+				has_character_flag = has_ill_child_loc
+				has_character_flag = has_money_troubles_loc
+				has_character_flag = has_a_rival_loc
+				has_character_flag = has_some_illness_loc
+				has_character_flag = has_need_of_winning_battles_loc
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetDWDevil # Returns a an appropriate name for the Devil (Fellow scripters, do expand upon all of the following once you have a good one)
+
+	text = {
+		localisation_key = String_Satan
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Iblis
+		trigger = {
+			society_member_of = the_satanists
+			religion_group = muslim
+		}
+	}
+	text = {
+		localisation_key = String_Ahriman
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Chernobog
+		trigger = { society_member_of = the_cold_ones }
+	}
+	text = {
+		localisation_key = String_Kali
+		trigger = { society_member_of = the_cult_of_kali }
+	}
+	text = {
+		localisation_key = String_Erlik
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = String_Hel
+		trigger = { society_member_of = the_trollcrafters }
+	}
+}
+
+defined_text = {
+	name = GetDWDarkMagic # Returns a an appropriate name for dark magic
+
+	text = {
+		localisation_key = String_black_magic
+		trigger = { 
+			society_member_of = the_satanists 
+			religion_group = christian
+		} 
+	}
+	text = {
+		localisation_key = String_sihr
+		trigger = { 
+			society_member_of = the_satanists 
+			religion_group = muslim
+		} 
+	}
+	text = {
+		localisation_key = String_Qliphoth
+		trigger = { 
+			society_member_of = the_satanists 
+			religion_group = jewish_group
+		} 
+	}
+	text = {
+		localisation_key = String_black_magic
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_koldovstvo
+		trigger = { society_member_of = the_cold_ones } 
+	}
+	text = {
+		localisation_key = String_seiðr
+		trigger = { society_member_of = the_trollcrafters } 
+	}
+	text = {
+		localisation_key = String_black_magic
+		trigger = { society_member_of = the_plaguebringers } 
+	}
+	text = {
+		localisation_key = String_dark_tantras
+		trigger = { society_member_of = the_cult_of_kali } 
+	}
+}
+
+defined_text = {
+	name = GetDWDemon # Returns a an appropriate name for a demon
+
+	text = {
+		localisation_key = String_demon
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		} 
+	}
+	text = {
+		localisation_key = String_jinn
+		trigger = { 
+			society_member_of = the_satanists 
+			religion_group = muslim
+		} 
+	}
+	text = {
+		localisation_key = String_likho
+		trigger = { society_member_of = the_cold_ones } 
+	}
+	text = {
+		localisation_key = String_jotun
+		trigger = { society_member_of = the_trollcrafters } 
+	}
+	text = {
+		localisation_key = string_karaoglan
+		trigger = { society_member_of = the_plaguebringers } 
+	}
+	text = {
+		localisation_key = String_rakshasa
+		trigger = { society_member_of = the_cult_of_kali } 
+	}
+	fallback_text = {
+		localisation_key = String_demon
+	}
+}
+
+defined_text = {
+	name = GetDWDemons # Returns a an appropriate name for demons
+
+	text = {
+		localisation_key = String_demons
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		} 
+	}
+	text = {
+		localisation_key = String_jinns
+		trigger = { 
+			society_member_of = the_satanists 
+			religion_group = muslim
+		} 
+	}
+	text = {
+		localisation_key = String_likhos
+		trigger = { society_member_of = the_cold_ones } 
+	}
+	text = {
+		localisation_key = String_jotnar
+		trigger = { society_member_of = the_trollcrafters } 
+	}
+	text = {
+		localisation_key = string_karaoglanlar 
+		trigger = { society_member_of = the_plaguebringers } 
+	}
+	text = {
+		localisation_key = String_rakshasas
+		trigger = { society_member_of = the_cult_of_kali } 
+	}
+	fallback_text = {
+		localisation_key = String_demons
+	}
+}
+
+defined_text = {
+	name = GetDWMagician 
+
+	text = {
+		localisation_key = String_witch
+		trigger = {
+			is_female = yes
+			society_member_of = the_satanists
+		}
+	}
+	text = {
+		localisation_key = String_warlock
+		trigger = {
+			is_female = no
+			society_member_of = the_satanists
+		}
+	}
+	text = {
+		localisation_key = String_koldunya
+		trigger = {
+			is_female = yes
+			society_member_of = the_cold_ones
+		}
+	}
+	text = {
+		localisation_key = String_koldun
+		trigger = {
+			is_female = no
+			society_member_of = the_cold_ones
+		}
+	}
+	text = {
+		localisation_key = String_seiðkona
+		trigger = {
+			is_female = yes
+			society_member_of = the_trollcrafters
+		}
+	}
+	text = {
+		localisation_key = String_seiðmaðr
+		trigger = {
+			is_female = no
+			society_member_of = the_trollcrafters
+		}
+	}
+	text = {
+		localisation_key = string_black_shaman
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = String_dark_tantrik
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+	}
+}
+
+defined_text = {
+	name = GetDWMagicianPlural
+
+	text = {
+		localisation_key = String_witches
+		trigger = {
+			is_female = yes
+			society_member_of = the_satanists
+		}
+	}
+	text = {
+		localisation_key = String_warlocks
+		trigger = {
+			is_female = no
+			society_member_of = the_satanists
+		}
+	}
+	text = {
+		localisation_key = String_koldunyas
+		trigger = {
+			is_female = yes
+			society_member_of = the_cold_ones
+		}
+	}
+	text = {
+		localisation_key = String_kolduns
+		trigger = {
+			is_female = no
+			society_member_of = the_cold_ones
+		}
+	}
+	text = {
+		localisation_key = String_seiðkonur
+		trigger = {
+			is_female = yes
+			society_member_of = the_trollcrafters
+		}
+	}
+	text = {
+		localisation_key = String_seiðmenn
+		trigger = {
+			is_female = no
+			society_member_of = the_trollcrafters
+		}
+	}
+	text = {
+		localisation_key = string_black_shamans
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = String_dark_tantriks
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+	}
+}
+
+defined_text = {
+	name = GetDWExpression
+
+	text = {
+		localisation_key = String_Glory_to_the_Deceiver
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Glory_to_Shaitan
+		trigger = {
+			society_member_of = the_satanists
+			religion_group = muslim
+		}
+	}
+	text = {
+		localisation_key = String_Glory_to_the_Black_God
+		trigger = { society_member_of = the_cold_ones }
+	}
+	text = {
+		localisation_key = String_Glory_to_the_Lord_of_Kali_Yuga
+		trigger = { society_member_of = the_cult_of_kali }
+	}
+	text = {
+		localisation_key = String_Glory_to_the_God_of_Death
+		trigger = { society_member_of = the_plaguebringers }
+	}
+	text = {
+		localisation_key = String_Glory_to_Hel
+		trigger = { society_member_of = the_trollcrafters }
+	}
+}
+
+defined_text = {
+	name = GetAssassinsCrimeOutcry
+	text = {
+		localisation_key = String_Death_to_the_infidels
+		trigger = { 
+			OR = { 
+				has_character_flag = assassins_target_war_attacker 
+				has_character_flag = assassins_target_war_attacker_vassal
+				has_character_flag = assassins_target_war_attacker_commander
+				has_character_flag = assassins_target_persecutes_shiites
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Grand_Master_Name_sends_herhis_regards
+		trigger = { 
+			has_character_flag = assassins_target_marked_for_death 
+			event_target:grand_master = { always = yes }
+		}
+	}
+	text = {
+		localisation_key = String_Blood_for_blood
+		trigger = { 
+			OR = {
+				has_character_flag = assassins_target_killed_member 
+				has_character_flag = assassins_target_assaulted_member
+			}
+		}
+	}
+	text = {
+		localisation_key = String_For_the_Assassins
+		trigger = { 
+			OR = {
+				AND = {
+					has_character_flag = assassins_target_marked_for_death 
+					NOT = { event_target:grand_master = { always = yes } }	
+				}
+				NOR = {
+					has_character_flag = assassins_target_war_attacker
+					has_character_flag = assassins_target_war_attacker_vassal
+					has_character_flag = assassins_target_war_attacker_commander
+					has_character_flag = assassins_target_persecutes_shiites
+					has_character_flag = assassins_target_marked_for_death
+					has_character_flag = assassins_target_killed_member
+					has_character_flag = assassins_target_assaulted_member
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Requiescat_in_pace
+		trigger = { culture_group = latin }
+		weight_multiplier = { factor = 0.1 }
+	}
+}
+
+defined_text = { #Does not work for jain and buddhist
+	name = GetMOGod
+
+	text = {
+		localisation_key = String_God
+		trigger = {
+			OR = {
+				society_member_of = monastic_order_dominican
+				society_member_of = monastic_order_benedictine
+				society_member_of = monastic_order_orthodox 
+				society_member_of = monastic_order_nestorian 
+				society_member_of = monastic_order_monophysite 
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Vishnu
+		trigger = {
+			OR = {
+				trait = smartist_hindu
+				trait = vaishnavist_hindu 
+			}
+			society_member_of = monastic_order_hindu
+		}
+	}
+	text = {
+		localisation_key = String_Devi
+		trigger = {
+			OR = {
+				trait = smartist_hindu
+				trait = shaktist_hindu 
+			}
+			society_member_of = monastic_order_hindu
+		}
+	}
+	text = {
+		localisation_key = String_Shiva
+		trigger = {
+			OR = {
+				trait = smartist_hindu
+				trait = shaivist_hindu 
+			}
+			society_member_of = monastic_order_hindu
+		}
+	}
+}
+
+defined_text = {
+	name = GetMOSaint
+	
+	text = {
+		localisation_key = String_Saint_Benedict
+		trigger = { society_member_of = monastic_order_benedictine }
+	}
+	text = {
+		localisation_key = String_Saint_Dominic
+		trigger = { society_member_of = monastic_order_dominican }
+	}
+	text = {
+		localisation_key = String_Saint_Basil
+		trigger = { society_member_of = monastic_order_orthodox }
+	}	
+	text = {
+		localisation_key = String_Saint_Abraham
+		trigger = { society_member_of = monastic_order_nestorian }
+	}	
+	text = {
+		localisation_key = String_Saint_Anthony
+		trigger = { society_member_of = monastic_order_monophysite }
+	}
+	text = {
+		localisation_key = String_Buddha
+		trigger = { society_member_of = monastic_order_buddhist }
+	}
+	text = {
+		localisation_key = String_Adi_Shankara
+		trigger = { society_member_of = monastic_order_hindu }
+	}
+	text = {
+		localisation_key = String_Acharya_Kundakunda
+		trigger = { society_member_of = monastic_order_jain }
+	}
+}
+
+defined_text = {
+	name = GetMOBuilding
+
+	text = {
+		localisation_key = String_monastery
+		trigger = {
+			OR = {
+				society_member_of = monastic_order_dominican
+				society_member_of = monastic_order_benedictine
+				society_member_of = monastic_order_orthodox 
+				society_member_of = monastic_order_nestorian 
+				society_member_of = monastic_order_monophysite 
+			}
+		}
+	}
+	text = {
+		localisation_key = String_matha
+		trigger = { society_member_of = monastic_order_hindu }
+	}
+	text = {
+		localisation_key = String_temple
+		trigger = {
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetMOCode
+
+	text = {
+		localisation_key = String_the_Rule_of_Saint_Benedict
+		trigger = { society_member_of = monastic_order_benedictine }
+	}
+	text = {
+		localisation_key = String_the_Rule_of_Saint_Augustine
+		trigger = { society_member_of = monastic_order_dominican }
+	}
+	text = {
+		localisation_key = String_the_Rule_of_Saint_Basil
+		trigger = { society_member_of = monastic_order_orthodox }
+	}	
+	text = {
+		localisation_key = String_the_Rule_of_Saint_Abraham
+		trigger = { society_member_of = monastic_order_nestorian }
+	}	
+	text = {
+		localisation_key = String_the_Rule_of_Saint_Anthony
+		trigger = { society_member_of = monastic_order_monophysite }
+	}		
+	text = {
+		localisation_key = String_the_Noble_Eightfold_Path
+		trigger = { society_member_of = monastic_order_buddhist }
+	}
+	text = {
+		localisation_key = String_the_four_Purusartha
+		trigger = { society_member_of = monastic_order_hindu }
+	}
+	text = {
+		localisation_key = String_the_Anuvrata
+		trigger = { society_member_of = monastic_order_jain }
+	}
+}
+
+defined_text = {
+	name = GetMOPenanceMeditation
+	text = {
+		localisation_key = String_doing_penance
+		trigger = { is_christian_monastic_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_in_meditation
+		trigger = { is_dharmic_monastic_member_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetMOGreeting
+	text = {
+		localisation_key = String_Gods_blessing_upon_thee
+		trigger = { is_christian_monastic_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Peace_be_upon_you
+		trigger = { is_dharmic_monastic_member_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetMOFarewell
+	text = {
+		localisation_key = String_Go_with_God
+		trigger = { is_christian_monastic_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Shubhaste_panthanah_santu
+		trigger = { is_dharmic_monastic_member_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetSRGreeting 
+	text = {
+		localisation_key = String_Gods_blessing_upon_thee
+		trigger = { 
+			OR = {
+				is_christian_secret_religious_society_member_trigger = yes 
+				society_member_of = secret_religious_society_yazidi
+				society_member_of = secret_religious_society_druze
+				society_member_of = secret_religious_society_mazdaki
+				society_member_of = secret_religious_society_manichean
+			}
+		}
+	}
+	text = {
+		localisation_key = String_As_salam_alaykum
+		trigger = { 
+			is_muslim_secret_religious_society_member_trigger = yes 
+			NOR = {
+				society_member_of = secret_religious_society_yazidi
+				society_member_of = secret_religious_society_druze
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Peace_be_upon_you
+		trigger = {
+			OR = {
+				is_indian_secret_religious_society_member_trigger = yes 
+				is_bon_secret_religious_society_member_trigger = yes
+				is_taoist_secret_religious_society_member_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Shalom_aleikhem
+		trigger = { is_jewish_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Hamazor_hama_asho_bed
+		trigger = { is_zoroastrian_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Allfathers_strength
+		trigger = { is_norse_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Svarogs_blessings
+		trigger = { is_slavic_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Ancestors_blessings
+		trigger = { is_tengri_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Dievas_blessings
+		trigger = { is_baltic_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Ukkos_blessings
+		trigger = { is_finnish_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Ancestors_blessings
+		trigger = { is_west_african_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Zuns_blessings
+		trigger = { is_zun_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Huitzilopochtlis_strength_to_you
+		trigger = { is_aztec_secret_religious_society_member_trigger = yes }
+	}
+	
+}
+
+defined_text = {
+	name = GetSRFarewell
+	text = {
+		localisation_key = String_Go_with_God
+		trigger = { 
+			OR = {
+				is_christian_secret_religious_society_member_trigger = yes 
+				society_member_of = secret_religious_society_yazidi
+				society_member_of = secret_religious_society_druze
+				society_member_of = secret_religious_society_mazdaki
+				society_member_of = secret_religious_society_manichean
+			}
+		}
+	}
+	text = {
+		localisation_key = String_May_Allah_guide_you
+		trigger = { 
+			is_muslim_secret_religious_society_member_trigger = yes 
+			NOR = {
+				society_member_of = secret_religious_society_yazidi
+				society_member_of = secret_religious_society_druze
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Shubhaste_panthanah_santu
+		trigger = { is_indian_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_May_Yehovah_guide_you
+		trigger = { is_jewish_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Humata_Hukta_Huvarashta
+		trigger = { is_zoroastrian_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_the_Gods_protect_you
+		trigger = { is_norse_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_May_the_Gods_protect_you
+		trigger = { is_slavic_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_the_Ancestors_guide_you
+		trigger = { is_tengri_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_the_Gods_protect_you
+		trigger = { is_baltic_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_the_Gods_protect_you
+		trigger = { is_finnish_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_the_Ancestors_guide_you
+		trigger = { is_west_african_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_May_Zun_illuminate_your_path
+		trigger = { is_zun_secret_religious_society_member_trigger = yes }
+	}
+
+	text = {
+		localisation_key = String_Fire_and_blood
+		trigger = { is_aztec_secret_religious_society_member_trigger = yes }
+	}
+	
+	text = {
+		localisation_key = String_May_the_Ancestors_guide_you
+		trigger = {
+			OR = {
+				is_bon_secret_religious_society_member_trigger = yes
+				is_taoist_secret_religious_society_member_trigger = yes
+			}
+		}
+	}
+	
+}
+
+defined_text = {
+	name = GetSRTrinketSymbol
+	text = {
+		localisation_key = String_Cross
+		trigger = { is_christian_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_crescent
+		trigger = { is_muslim_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_six_pointed_star
+		trigger = { is_jewish_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_figurine_of_Buddha
+		trigger = { true_religion_buddhist_trigger = yes }
+	}
+	text = {
+		localisation_key = String_figurine_of_Ganesha
+		trigger = { true_religion_hindu_trigger = yes }
+	}
+	text = {
+		localisation_key = String_figurine_of_jain_god
+		trigger = { true_religion_jain_trigger = yes }
+	}
+	text = {
+		localisation_key = String_fire_symbol
+		trigger = { true_religion_group_zoroastrian_group_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Thors_hammer
+		trigger = { is_norse_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_hatchet_amulet
+		trigger = { is_slavic_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_world_tree_symbol
+		trigger = { is_baltic_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_life_tree_symbol
+		trigger = { is_tengri_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Ukkos_hammer
+		trigger = { is_finnish_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_ancestors_symbol
+		trigger = { is_west_african_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_sun_symbol
+		trigger = { is_zun_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Fire_and_blood
+		trigger = { is_aztec_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Animal_made_of_bread
+		trigger = { is_bon_secret_religious_society_member_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Yinyang_symbol
+		trigger = { is_taoist_secret_religious_society_member_trigger = yes }
+	}
+}
+
+#Hermes Tirismegistus or other suitably old person spreading arcane and ancient knowledge
+defined_text = {
+	name = GetHermesThriceBlessed
+
+	text = {
+		trigger = { NOT = { religion_group = muslim } }
+		localisation_key = String_hermes_trismegistus
+	}
+	text = {
+		trigger = { religion_group = muslim }
+		localisation_key = String_idris
+	}
+}
+
+defined_text = {
+	name = GetFromThisHermeticsRank
+	text = {
+		trigger = { 
+			is_liege_of = FROM
+			FROM = { has_minor_title = title_hermetics_apprentice }
+		}
+		localisation_key = String_GetMasterMistress
+	}
+	text = {
+		trigger = { 
+			NAND = {
+				is_liege_of = FROM
+				FROM = { has_minor_title = title_hermetics_apprentice }
+			}
+		}
+		localisation_key = String_GetSocietyRank
+	}
+}
+
+
+
+###RELIGION###
+defined_text = {
+	name = GetHouseOfWorship # Returns a suitable name for the house of worship of your religion (WIP)
+
+	text = {
+		localisation_key = GetHouseOfWorship_Christian
+		trigger = { religion_group = christian }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Muslim
+		trigger = { religion_group = muslim }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Pagan
+		trigger = { religion_group = pagan_group }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Zoroastrian
+		trigger = { religion_group = zoroastrian_group }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Jewish
+		trigger = { religion_group = jewish_group }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Hindu
+		trigger = { religion = hindu }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Buddhist
+		trigger = { religion = buddhist }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Jain
+		trigger = { religion = jain }
+	}
+	text = {
+		localisation_key = GetHouseOfWorship_Taoist
+		trigger = { religion = taoist }
+	}
+}
+
+defined_text = {
+	name = GetHouseOfWorshipCap # Returns a suitable name for the house of worship of your religion (WIP)
+
+	text = {
+		localisation_key = string_Church
+		trigger = { religion_group = christian }
+	}
+	text = {
+		localisation_key = string_Mosque
+		trigger = { religion_group = muslim }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = pagan_group }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = zoroastrian_group }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = jewish_group }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion = hindu }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion = buddhist }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion = jain }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion = taoist }
+	}
+	fallback_text = {
+		localisation_key = string_Temple
+	}
+}
+
+
+defined_text = {
+	name = GetReligiousRite # Returns a suitable name for a common rite in the character's religion
+
+	text = {
+		localisation_key = String_mass
+		trigger = { religion_group = christian }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = muslim }
+	}
+	text = {
+		localisation_key = String_worship
+		trigger = { religion_group = pagan_group }
+	}
+	text = {
+		localisation_key = String_worship
+		trigger = { religion_group = zoroastrian_group }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = jewish_group }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = indian_group }
+	}
+}
+
+defined_text = {
+	name = GetReligionWarrior #Returns an appropriate word for a warrior/soldier depending on religion (and culture)
+
+	text = {
+		localisation_key = String_druzhinniki
+		trigger = {
+			OR = {
+				religion = slavic_pagan
+				religion = slavic_pagan_reformed
+				culture_group = east_slavic
+				culture = polish
+			}
+		}
+	}
+	text = {
+		localisation_key = String_huscarl
+		trigger = {
+			OR = {
+				religion = norse_pagan
+				religion = norse_pagan_reformed
+				AND = {
+					OR = {
+						culture_group = north_germanic
+						culture = saxon
+						culture = old_saxon
+					}
+					is_tribal = yes
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_man_at_arm
+		trigger = {
+			religion = catholic
+			is_tribal = no
+			is_nomadic = no
+		}
+	}
+	text = {
+		localisation_key = String_spahi
+		trigger = {
+			culture_group = iranian
+		}
+	}
+	text = {
+		localisation_key = String_ghazi
+		trigger = {
+			religion_group = muslim
+		}
+	}
+	text = {
+		localisation_key = String_sainik
+		trigger = {
+			OR = {
+				culture_group = indo_aryan_group
+				culture_group = dravidian_group
+			}
+		}
+	}
+	text = {
+		localisation_key = String_kheshig
+		trigger = {
+			culture_group = altaic
+		}
+	}
+
+	text = {
+		localisation_key = String_warrior
+		#generic
+	}
+}
+
+defined_text = {
+	name = GetReligionWarriorPlural #Returns an appropriate word for a warrior/soldier depending on religion (and culture)
+
+	text = {
+		localisation_key = String_druzhinniki
+		trigger = {
+			OR = {
+				religion = slavic_pagan
+				religion = slavic_pagan_reformed
+				culture_group = east_slavic
+				culture = polish
+			}
+		}
+	}
+	text = {
+		localisation_key = String_huscarls
+		trigger = {
+			OR = {
+				religion = norse_pagan
+				religion = norse_pagan_reformed
+				AND = {
+					OR = {
+						culture_group = north_germanic
+						culture = saxon
+						culture = old_saxon
+					}
+					is_tribal = yes
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_men_at_arms
+		trigger = {
+			religion = catholic
+			is_tribal = no
+			is_nomadic = no
+		}
+	}
+	text = {
+		localisation_key = String_spahis
+		trigger = {
+			culture_group = iranian
+		}
+	}
+	text = {
+		localisation_key = String_ghazis
+		trigger = {
+			religion_group = muslim
+		}
+	}
+	text = {
+		localisation_key = String_sainikon
+		trigger = {
+			OR = {
+				culture_group = indo_aryan_group
+				culture_group = dravidian_group
+			}
+		}
+	}
+	text = {
+		localisation_key = String_kheshig
+		trigger = {
+			culture_group = altaic
+		}
+	}
+
+	text = {
+		localisation_key = String_warriors
+		#generic
+	}
+}
+
+defined_text = { 
+	name = GetReligiousPerson
+	text = { 
+		localisation_key = String_Catholic
+		trigger = { religion = catholic }
+	}
+	text = { 
+		localisation_key = String_Christian
+		trigger = { 
+			religion_group = christian
+			NOT = { religion = catholic }
+		}
+	}
+	text = {
+		localisation_key = String_Muslim
+		trigger = { religion_group = muslim }
+	}
+	text = {
+		localisation_key = String_Jew
+		trigger = { religion_group = jewish_group }
+	}
+	text = {
+		localisation_key = String_Zoroastrian
+		trigger = { religion_group = zoroastrian_group }
+	}
+	text = { 
+		localisation_key = String_Buddhist
+		trigger = { religion = buddhist }
+	}
+	text = { 
+		localisation_key = String_Jain
+		trigger = { religion = jain }
+	}
+	text = { 
+		localisation_key = String_Hindu
+		trigger = { religion = hindu }
+	}
+	text = { 
+		localisation_key = String_Taoist
+		trigger = { religion = taoist }
+	}
+	text = {
+		localisation_key = String_Norse
+		trigger = { 
+			OR = {
+				religion = norse_pagan
+				religion = norse_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Slav
+		trigger = { 
+			OR = {
+				religion = slavic_pagan
+				religion = slavic_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Romuvan
+		trigger = { 
+			OR = {
+				religion = baltic_pagan
+				religion = baltic_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Finn
+		trigger = { 
+			OR = {
+				religion = finnish_pagan
+				religion = finnish_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_West_African
+		trigger = { 
+			OR = {
+				religion = west_african_pagan
+				religion = west_african_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tengri
+		trigger = { 
+			OR = {
+				religion = tengri_pagan
+				religion = tengri_pagan_reformed
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Zun
+		trigger = { 
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetArtifactSource
+	text = {
+		localisation_key = String_saint
+		trigger = {
+			religion_group = christian
+		}
+	}
+	text = {
+		localisation_key = String_famous_holy_man
+		trigger = {
+			OR = {
+				religion_group = zoroastrian_group
+				religion_group = indian_group
+				religion_group = jewish_group
+				religion_group = muslim
+			}
+		}
+	}
+	text = {
+		localisation_key = String_great_hero
+		trigger = {
+			religion_group = pagan_group
+		}
+	}
+}
+
+defined_text = {
+	name = GetArtifactSourceCap
+	text = {
+		localisation_key = String_Saint_cap
+		trigger = {
+			religion_group = christian
+		}
+	}
+	text = {
+		localisation_key = String_Famous_Holy_Man_cap
+		trigger = {
+			OR = {
+				religion_group = zoroastrian_group
+				religion_group = indian_group
+				religion_group = jewish_group
+				religion_group = muslim
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Great_Hero_cap
+		trigger = {
+			religion_group = pagan_group
+		}
+	}
+}
+
+defined_text = { #WIP
+	name = GetPrayers
+	text = { 
+		localisation_key = String_prayers
+		trigger = { religion_group = christian }
+	}
+	text = { 
+		localisation_key = String_mantras
+		trigger = { religion_group = indian_group }
+	}	
+}
+
+defined_text = {
+	name = GetTrueReligionGroupPersons 
+
+	text = { 
+		localisation_key = String_Christians
+		trigger = { true_religion_group_christian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Muslims
+		trigger = { true_religion_group_muslim_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_pagans
+		trigger = { true_religion_group_pagan_group_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Zoroastrians
+		trigger = { true_religion_group_zoroastrian_group_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Jews
+		trigger = { true_religion_group_jewish_group_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Indians
+		trigger = { true_religion_group_indian_group_trigger = yes }
+	}
+}
+
+
+defined_text = {
+	name = GetTrueReligionAdjective
+
+	text = { 
+		localisation_key = String_Catholic
+		trigger = { true_religion_catholic_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Cathar
+		trigger = { true_religion_cathar_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Fraticelli
+		trigger = { true_religion_fraticelli_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Waldesian
+		trigger = { true_religion_waldensian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Lollard
+		trigger = { true_religion_lollard_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Orthodox
+		trigger = { true_religion_orthodox_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Bogomilist
+		trigger = { true_religion_bogomilist_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Monothelite
+		trigger = { true_religion_monothelite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Iconoclast
+		trigger = { true_religion_iconoclast_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Paulician
+		trigger = { true_religion_paulician_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Miaphysite
+		trigger = { true_religion_miaphysite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Monophysite
+		trigger = { true_religion_monophysite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Nestorian
+		trigger = { true_religion_nestorian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Messalian
+		trigger = { true_religion_messalian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Sunni
+		trigger = { true_religion_sunni_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Zikri
+		trigger = { true_religion_zikri_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Yazidi
+		trigger = { true_religion_yazidi_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Shia
+		trigger = { true_religion_shiite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Druze
+		trigger = { true_religion_druze_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Hurufi
+		trigger = { true_religion_hurufi_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Ibadi
+		trigger = { true_religion_ibadi_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Kharijite
+		trigger = { true_religion_kharijite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Jewish
+		trigger = { true_religion_jewish_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Samaritan
+		trigger = { true_religion_samaritan_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Karaite
+		trigger = { true_religion_karaite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Zoroastrian
+		trigger = { true_religion_zoroastrian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Mazdaki
+		trigger = { true_religion_mazdaki_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Manichean
+		trigger = { true_religion_manichean_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Hindu
+		trigger = { true_religion_hindu_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Buddhist
+		trigger = { true_religion_buddhist_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Jain
+		trigger = { true_religion_jain_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Norse
+		trigger = { 
+			OR = {
+				true_religion_norse_pagan_reformed_trigger = yes 
+				true_religion_norse_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Slavic
+		trigger = { 
+			OR = {
+				true_religion_slavic_pagan_reformed_trigger = yes 
+				true_religion_slavic_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Tengri
+		trigger = { 
+			OR = {
+				true_religion_tengri_pagan_reformed_trigger = yes 
+				true_religion_tengri_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Romuva
+		trigger = { 
+			OR = {
+				true_religion_baltic_pagan_reformed_trigger = yes 
+				true_religion_baltic_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Suomenusko
+		trigger = { 
+			OR = {
+				true_religion_finnish_pagan_reformed_trigger = yes 
+				true_religion_finnish_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_West_African
+		trigger = { 
+			OR = {
+				true_religion_west_african_pagan_reformed_trigger = yes 
+				true_religion_west_african_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Zun
+		trigger = { 
+			OR = {
+				true_religion_zun_pagan_reformed_trigger = yes 
+				true_religion_zun_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Aztec
+		trigger = { 
+			OR = {
+				true_religion_aztec_reformed_trigger = yes 
+				true_religion_aztec_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = khurmazta
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = bon
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = taoist
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetTrueReligionAdherent
+
+	text = {
+		localisation_key = String_Catholic
+		trigger = { true_religion_catholic_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Orthodox_Christian
+		trigger = { true_religion_orthodox_trigger = yes }
+	}
+	text = {
+		localisation_key = cathar
+		trigger = { true_religion_cathar_trigger = yes }
+	}
+	text = {
+		localisation_key = fraticelli
+		trigger = { true_religion_fraticelli_trigger = yes }
+	}
+	text = {
+		localisation_key = waldensian
+		trigger = { true_religion_waldensian_trigger = yes }
+	}
+	text = {
+		localisation_key = lollard
+		trigger = { true_religion_lollard_trigger = yes }
+	}
+	text = {
+		localisation_key = bogomilist
+		trigger = { true_religion_bogomilist_trigger = yes }
+	}
+	text = {
+		localisation_key = monothelite
+		trigger = { true_religion_monothelite_trigger = yes }
+	}
+	text = {
+		localisation_key = iconoclast
+		trigger = { true_religion_iconoclast_trigger = yes }
+	}
+	text = {
+		localisation_key = paulician
+		trigger = { true_religion_paulician_trigger = yes }
+	}
+	text = {
+		localisation_key = miaphysite
+		trigger = { true_religion_miaphysite_trigger = yes }
+	}
+	text = {
+		localisation_key = monophysite
+		trigger = { true_religion_monophysite_trigger = yes }
+	}
+	text = {
+		localisation_key = nestorian
+		trigger = { true_religion_nestorian_trigger = yes }
+	}
+	text = {
+		localisation_key = messalian
+		trigger = { true_religion_messalian_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Sunni
+		trigger = { true_religion_sunni_trigger = yes }
+	}
+	text = { 
+		localisation_key = zikri
+		trigger = { true_religion_zikri_trigger = yes }
+	}
+	text = { 
+		localisation_key = yazidi
+		trigger = { true_religion_yazidi_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Shia
+		trigger = { true_religion_shiite_trigger = yes }
+	}
+	text = { 
+		localisation_key = druze
+		trigger = { true_religion_druze_trigger = yes }
+	}
+	text = { 
+		localisation_key = hurufi
+		trigger = { true_religion_hurufi_trigger = yes }
+	}
+	text = { 
+		localisation_key = ibadi
+		trigger = { true_religion_ibadi_trigger = yes }
+	}
+	text = { 
+		localisation_key = kharijite
+		trigger = { true_religion_kharijite_trigger = yes }
+	}	
+	text = { 
+		localisation_key = String_Jew
+		trigger = { true_religion_jewish_trigger = yes }
+	}
+	text = { 
+		localisation_key = samaritan
+		trigger = { true_religion_samaritan_trigger = yes }
+	}
+	text = { 
+		localisation_key = karaite
+		trigger = { true_religion_karaite_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Zoroastrian
+		trigger = { true_religion_zoroastrian_trigger = yes }
+	}
+	text = { 
+		localisation_key = mazdaki
+		trigger = { true_religion_mazdaki_trigger = yes }
+	}
+	text = { 
+		localisation_key = manichean
+		trigger = { true_religion_manichean_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Hindu
+		trigger = { true_religion_hindu_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Buddhist
+		trigger = { true_religion_buddhist_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Jain
+		trigger = { true_religion_jain_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Norse_Follower
+		trigger = { true_religion_norse_pagan_reformed_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Slav
+		trigger = { true_religion_slavic_pagan_reformed_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Tengri
+		trigger = { true_religion_tengri_pagan_reformed_trigger = yes }
+	}
+	 text = { 
+		localisation_key = String_Romuvan
+		trigger = { true_religion_baltic_pagan_reformed_trigger = yes }
+	}
+	 text = { 
+		localisation_key = String_Suomenusko_Follower
+		trigger = { true_religion_finnish_pagan_reformed_trigger = yes }
+	}
+	 text = { 
+		localisation_key = String_West_African
+		trigger = { true_religion_west_african_pagan_reformed_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Zunist
+		trigger = { true_religion_zun_pagan_reformed_trigger = yes }
+	}
+	text = { 
+		localisation_key = aztec_reformed
+		trigger = { true_religion_aztec_reformed_trigger = yes }
+	}
+	
+	text = { 
+		localisation_key = aztec
+		trigger = { true_religion_aztec_trigger = yes }
+	}
+	text = { 
+		localisation_key = norse_pagan
+		trigger = { true_religion_norse_pagan_trigger = yes }
+	}
+	text = { 
+		localisation_key = slavic_pagan
+		trigger = { true_religion_slavic_pagan_trigger = yes }
+	}
+	text = { 
+		localisation_key = tengri_pagan
+		trigger = { true_religion_tengri_pagan_trigger = yes }
+	}
+	 text = { 
+		localisation_key = baltic_pagan
+		trigger = { true_religion_baltic_pagan_trigger = yes }
+	}
+	 text = { 
+		localisation_key = finnish_pagan
+		trigger = { true_religion_finnish_pagan_trigger = yes }
+	}
+	 text = { 
+		localisation_key = west_african_pagan
+		trigger = { true_religion_west_african_pagan_trigger = yes }
+	}
+	text = { 
+		localisation_key = zun_pagan
+		trigger = { true_religion_zun_pagan_trigger = yes }
+	}
+	text = { 
+		localisation_key = khurmazta
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = bon
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = taoist
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetTrueReligionHighGod
+
+	text = {
+		localisation_key = GOD_GOD
+		trigger = { 
+			true_religion_group_christian_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = GOD_ALLAH
+		trigger = {
+			true_religion_group_muslim_trigger = yes
+			NOT = { true_religion_yazidi_trigger = yes }
+		}
+	}
+	text = { 
+		localisation_key = GOD_SHAYTAN
+		trigger = { true_religion_yazidi_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_GOD
+		trigger = { true_religion_group_jewish_group_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_AHURA_MAZDA
+		trigger = { 
+			true_religion_group_zoroastrian_group_trigger = yes 
+			NOT = { true_religion_manichean_trigger = yes }
+		}
+	}
+	text = { 
+		localisation_key = GOD_ZURVAN
+		trigger = { true_religion_manichean_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_BRAHMA
+		trigger = { true_religion_hindu_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_BRAHMA
+		trigger = { true_religion_buddhist_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_THE_TIRTHANKARAS
+		trigger = { true_religion_jain_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_ODIN
+		trigger = { 
+			OR = {
+				true_religion_norse_pagan_reformed_trigger = yes 
+				true_religion_norse_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = GOD_PERUN
+		trigger = { 
+			OR = {
+				true_religion_slavic_pagan_reformed_trigger = yes 
+				true_religion_slavic_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = GOD_TENGRI
+		trigger = { 
+			OR = {
+				true_religion_tengri_pagan_reformed_trigger = yes 
+				true_religion_tengri_pagan_trigger = yes
+			}
+		}
+	}
+	 text = { 
+		localisation_key = GOD_DIEVAS
+		trigger = { 
+			OR = {
+				true_religion_baltic_pagan_reformed_trigger = yes 
+				true_religion_baltic_pagan_trigger = yes
+			}
+		}
+	}
+	 text = { 
+		localisation_key = GOD_UKKO
+		trigger = { 
+			OR = {
+				true_religion_finnish_pagan_reformed_trigger = yes 
+				true_religion_finnish_pagan_trigger = yes
+			}
+		}
+	}
+	 text = { 
+		localisation_key = GOD_THE_CREATOR
+		trigger = { 
+			OR = {
+				true_religion_west_african_pagan_reformed_trigger = yes 
+				true_religion_west_african_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = GOD_ZUN
+		trigger = { 
+			OR = {
+				true_religion_zun_pagan_reformed_trigger = yes 
+				true_religion_zun_pagan_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = GOD_HUITZILOPOCHTLI
+		trigger = { 
+			OR = {
+				true_religion_aztec_reformed_trigger = yes 
+				true_religion_aztec_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = GOD_ZARVANA
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_SANGPO_BUMTRI
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = GOD_HEAVENLY_ORDER
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetTrueReligionScriptureName
+    text = {
+        localisation_key = String_Bible
+        trigger = { 
+            true_religion_group_christian_trigger = yes
+            NOT = { true_religion_messalian_trigger = yes }
+        }
+    }
+    text = { 
+        localisation_key = String_Asceticus
+        trigger = { true_religion_messalian_trigger = yes }
+    }
+    text = {
+        localisation_key = String_Koran
+        trigger = { 
+            true_religion_group_muslim_trigger = yes
+            NOT = { true_religion_yazidi_trigger = yes }
+            NOT = { true_religion_druze_trigger = yes }
+        }
+    }
+    text = { 
+        localisation_key = String_Book_of_Illumination
+        trigger = { true_religion_yazidi_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Epistles_of_Wisdom
+        trigger = { true_religion_druze_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Torah
+        trigger = { true_religion_group_jewish_group_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Gathas
+        trigger = { 
+            true_religion_group_zoroastrian_group_trigger = yes 
+            NOT = { true_religion_mazdaki_trigger = yes }
+        }
+    }
+    text = { 
+        localisation_key = String_Great_Secret
+        trigger = { true_religion_mazdaki_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Mahabharata
+        trigger = { true_religion_hindu_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Buddhacavana
+        trigger = { true_religion_buddhist_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Mahabharata
+        trigger = { true_religion_jain_trigger = yes }
+    }
+    text = { 
+        localisation_key = String_Sagas
+        trigger = { 
+            OR = {
+                true_religion_norse_pagan_trigger = yes
+                true_religion_norse_pagan_reformed_trigger = yes
+            }
+        }
+    }
+    text = { 
+        localisation_key = String_Legends
+        trigger = { 
+            true_religion_group_pagan_group_trigger = yes
+            NOR = {
+                true_religion_norse_pagan_trigger = yes
+                true_religion_norse_pagan_reformed_trigger = yes
+            }
+        }
+    }
+	text = { 
+		localisation_key = THE_GATHAS
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = MDODUS
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = TAO_TE_CHING
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetTrueReligionPerson
+	text = { 
+		localisation_key = String_Catholic
+		trigger = { true_religion_catholic_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Christian
+		trigger = { 
+			true_religion_group_christian_trigger = yes
+			NOT = { true_religion_catholic_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_Muslim
+		trigger = { true_religion_group_muslim_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Jew
+		trigger = { true_religion_group_jewish_group_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Zoroastrian
+		trigger = { true_religion_group_zoroastrian_group_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Buddhist
+		trigger = { true_religion_buddhist_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Jain
+		trigger = { true_religion_jain_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_Hindu
+		trigger = { true_religion_hindu_trigger = yes }
+	}
+	text = {
+		localisation_key = String_Norse
+		trigger = { 
+			OR = {
+				true_religion_norse_pagan_trigger = yes
+				true_religion_norse_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Romuvan
+		trigger = { 
+			OR = {
+				true_religion_baltic_pagan_trigger = yes
+				true_religion_baltic_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Slav
+		trigger = { 
+			OR = {
+				true_religion_slavic_pagan_trigger = yes
+				true_religion_slavic_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Finn
+		trigger = { 
+			OR = {
+				true_religion_finnish_pagan_reformed_trigger = yes
+				true_religion_finnish_pagan_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tengri
+		trigger = { 
+			OR = {
+				true_religion_tengri_pagan_trigger = yes
+				true_religion_tengri_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_West_African
+		trigger = { 
+			OR = {
+				true_religion_west_african_pagan_trigger = yes
+				true_religion_west_african_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Zun
+		trigger = { 
+			OR = {
+				true_religion_zun_pagan_trigger = yes
+				true_religion_zun_pagan_reformed_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Aztec
+		trigger = { 
+			OR = {
+				true_religion_aztec_reformed_trigger = yes 
+				true_religion_aztec_trigger = yes
+			}
+		}
+	}
+	text = { 
+		localisation_key = khurmazta
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = bon
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = taoist
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+defined_text = {
+	name = GetReligionAdherent
+
+	text = {
+		localisation_key = String_Catholic
+		trigger = { religion = catholic }
+	}
+	text = {
+		localisation_key = String_Orthodox_Christian
+		trigger = { religion = orthodox }
+	}
+	text = {
+		localisation_key = String_Christian
+		trigger = {
+			religion_group = christian
+			NOT = { religion = catholic }
+			NOT = { religion = orthodox }
+		}
+	}
+	text = { 
+		localisation_key = String_Sunni
+		trigger = { religion = sunni }
+	}
+	text = { 
+		localisation_key = String_Shia
+		trigger = { religion = shiite }
+	}
+	text = {
+		localisation_key = String_Muslim
+		trigger = {
+			religion_group = muslim
+			NOT = { religion = sunni }
+			NOT = { religion = shiite }
+		}
+	}
+	text = { 
+		localisation_key = String_Jew
+		trigger = { religion = jewish }
+	}
+	text = { 
+		localisation_key = String_Zoroastrian
+		trigger = { religion = zoroastrian }
+	}
+	text = { 
+		localisation_key = String_Hindu
+		trigger = { religion = hindu }
+	}
+	text = { 
+		localisation_key = String_Buddhist
+		trigger = { religion = buddhist }
+	}
+	text = { 
+		localisation_key = String_Jain
+		trigger = { religion = jain }
+	}
+	text = { 
+		localisation_key = String_Taoist
+		trigger = { religion = taoist }
+	}
+	text = { 
+		localisation_key = String_Norse_Follower
+		trigger = {
+			OR = {
+				religion = norse_pagan_reformed
+				religion = norse_pagan
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Slav
+		trigger = {
+			OR = {
+				religion = slavic_pagan_reformed
+				religion = slavic_pagan
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tengri
+		trigger = {
+			OR = {
+				religion = tengri_pagan_reformed
+				religion = tengri_pagan
+			}
+		}
+	}
+	 text = { 
+		localisation_key = String_Romuvan
+		trigger = {
+			OR = {
+				religion = baltic_pagan_reformed
+				religion = baltic_pagan
+			}
+		}
+	}
+	 text = { 
+		localisation_key = String_Suomenusko_Follower
+		trigger = {
+			OR = {
+				religion = finnish_pagan_reformed
+				religion = finnish_pagan
+			}
+		}
+	}
+	 text = { 
+		localisation_key = String_West_African
+		trigger = {
+			OR = {
+				religion = west_african_pagan_reformed
+				religion = west_african_pagan
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_Zunist
+		trigger = {
+			OR = {
+				religion = zun_pagan_reformed
+				religion = zun_pagan
+			}
+		}
+	}
+	text = { 
+		localisation_key = String_khurmazta_faithful
+		trigger = { true_religion_khurmazta_trigger = yes }
+	}
+	text = { 
+		localisation_key = String_bon_faithful
+		trigger = { true_religion_bon_trigger = yes }
+	}
+	text = { 
+		localisation_key = taoist
+		trigger = { true_religion_taoist_trigger = yes }
+	}
+}
+
+###PLACES###
+defined_text = {
+	name = GetCapitalHolding # Returns a suitable name for the main building of your capital
+
+	text = {
+		localisation_key = GetHolding_Castle_1
+		trigger = {
+			capital_holding = { holding_type = castle	}
+			NOT = { higher_tier_than = DUKE }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Castle_2
+		trigger = {
+			capital_holding = { holding_type = castle	}
+			higher_tier_than = DUKE
+			NOT = { higher_tier_than = KING }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Castle_3
+		trigger = {
+			capital_holding = { holding_type = castle	}
+			higher_tier_than = KING
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Temple_1
+		trigger = { capital_holding = { holding_type = temple	} }
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_1
+		trigger = {
+			capital_holding = { holding_type = nomad }
+			NOT = { higher_tier_than = DUKE }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_2
+		trigger = {
+			capital_holding = { holding_type = nomad }
+			higher_tier_than = DUKE
+			NOT = { higher_tier_than = KING }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_3
+		trigger = {
+			capital_holding = { holding_type = nomad }
+			higher_tier_than = KING
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_1
+		trigger = {
+			capital_holding = { holding_type = tribal	}
+			NOT = { higher_tier_than = COUNT }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_2
+		trigger = {
+			capital_holding = { holding_type = tribal	}
+			higher_tier_than = COUNT
+			NOT = { higher_tier_than = DUKE }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_3
+		trigger = {
+			capital_holding = { holding_type = tribal	}
+			higher_tier_than = DUKE
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_1
+		trigger = {
+			capital_holding = { holding_type = city }
+			NOT = { higher_tier_than = DUKE }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_2
+		trigger = {
+			capital_holding = { holding_type = city }
+			higher_tier_than = DUKE
+			NOT = { higher_tier_than = KING }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_3
+		trigger = {
+			capital_holding = { holding_type = city }
+			higher_tier_than = KING
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Fallback_1
+		trigger = {
+			NOT = {
+				capital_holding = {
+					OR = {
+						holding_type = castle
+						holding_type = temple
+						holding_type = nomad
+						holding_type = tribal
+						holding_type = city
+					}
+				}
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetHolding # Returns a suitable name for a holding
+
+	text = {
+		localisation_key = GetHolding_Castle_1
+		trigger = {
+			holding_type = castle
+			county = { holder_scope = { NOT = { higher_tier_than = DUKE } } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Castle_2
+		trigger = {
+			holding_type = castle
+			county = { 
+				holder_scope = { 
+					higher_tier_than = DUKE
+					NOT = { higher_tier_than = KING }
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Castle_3
+		trigger = {
+			holding_type = castle
+			county = { holder_scope = { higher_tier_than = KING } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Temple_1
+		trigger = { holding_type = temple }
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_1
+		trigger = {
+			holding_type = nomad
+			county = { holder_scope = { NOT = { higher_tier_than = DUKE } } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_2
+		trigger = {
+			holding_type = nomad
+			county = { 
+				holder_scope = { 
+					higher_tier_than = DUKE
+					NOT = { higher_tier_than = KING }
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Nomad_3
+		trigger = {
+			holding_type = nomad
+			county = { holder_scope = { higher_tier_than = KING } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_1
+		trigger = {
+			holding_type = tribal
+			county = { holder_scope = { NOT = { higher_tier_than = COUNT } } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_2
+		trigger = {
+			holding_type = tribal
+			county = { 
+				holder_scope = { 
+					higher_tier_than = COUNT
+					NOT = { higher_tier_than = DUKE }
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = GetHolding_Tribal_3
+		trigger = {
+			holding_type = tribal
+			county = { holder_scope = { higher_tier_than = DUKE } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_1
+		trigger = {
+			holding_type = city
+			county = { holder_scope = { NOT = { higher_tier_than = DUKE } } }
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_2
+		trigger = {
+			holding_type = city
+			county = { 
+				holder_scope = { 
+					higher_tier_than = DUKE
+					NOT = { higher_tier_than = KING }
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = GetHolding_City_3
+		trigger = {
+			holding_type = city
+			county = { holder_scope = { higher_tier_than = KING } }
+		}
+	}
+	text = {
+		localisation_key = String_settlement
+		trigger = {
+			NOT = {
+				OR = {
+					holding_type = castle
+					holding_type = temple
+					holding_type = nomad
+					holding_type = tribal
+					holding_type = city
+				}	
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetChamberOpening
+	text = {
+		localisation_key = GetChamberOpening_Door
+		trigger = { 
+			NOR = { 
+				capital_scope = { holding_type = tribal }
+				capital_scope = { holding_type = nomad }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetChamberOpening_TentOpening
+		trigger = { 
+			OR = {
+				capital_scope = { holding_type = tribal }
+				capital_scope = { holding_type = nomad }
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetChamber
+	text = {
+		localisation_key = GetChamber_Chambers
+		trigger = {
+			NOR = { 
+				capital_scope = { holding_type = tribal }
+				capital_scope = { holding_type = nomad }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetChamber_Tent
+		trigger = {
+			OR = {
+				capital_scope = { holding_type = tribal }
+				capital_scope = { holding_type = nomad }
+			}
+		}
+	}
+}
+
+###WEATHER, TIME###
+defined_text = {
+	name = GetWeatherAdjective # WIP
+
+	text = {
+		localisation_key = GetWeatherAdjective_Sunny
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				capital_scope = { region = world_africa }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Rainy
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				trait = depressed
+			}
+
+			modifier = {
+				factor = 5
+				capital_scope = { region = world_india }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Snowy
+
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				capital_scope = { region = world_europe_north }
+			}
+		}
+
+		trigger = {
+			capital_scope = { region = world_europe }
+			AND = {
+				month = 10
+				NOT = { month = 3 }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Stormy
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 5
+				capital_scope = { is_coastal = yes }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Windy
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 5
+				capital_scope = { is_coastal = yes }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Cloudy
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 3
+				capital_scope = { is_coastal = yes }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetWeatherAdjective_Foggy
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 3
+				capital_scope = { is_coastal = yes }
+			}
+		}
+	}
+}
+
+
+defined_text = {
+	name = GetTemperature # WIP
+
+	text = {
+		localisation_key = GetTemperature_Sweltering
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				capital_scope = { region = world_africa }
+			}
+		}
+		trigger = {
+			month = 5
+			NOT = { month = 9 }
+		}
+	}
+	text = {
+		localisation_key = GetTemperature_Freezing
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 5
+				capital_scope = { region = world_europe_north }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetTemperature_Cold
+
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				capital_scope = { region = world_europe_north }
+			}
+		}
+
+		trigger = {
+			capital_scope = { region = world_europe }
+			AND = {
+				month = 10
+				NOT = { month = 3 }
+			}
+		}
+	}
+	text = {
+		localisation_key = GetTemperature_Warm
+		weight_multiplier = {
+			factor = 20
+		}
+	}
+}
+
+#defined_text = {
+#	name = GetSeason
+
+#	text = {
+#		trigger = { 
+#			NOR = {
+#				
+#			}
+#		}
+#		localisation_key = String_spring
+#	}
+#}
+
+
+#MISC
+defined_text = {
+	name = GetMatterOfImportance
+
+	text = {
+		trigger = { any_child = { is_female = yes } }
+		localisation_key = String_daughter
+		weight_multiplier = { factor = 3 }
+	}
+	text = {
+		trigger = { any_child = { is_female = no } }
+		localisation_key = String_son
+		weight_multiplier = { factor = 3 }
+	}
+	text = {
+		trigger = { is_married = yes }
+		localisation_key = String_GetHusbandWifeOpp
+		weight_multiplier = { factor = 3 }
+	}
+	text = {
+		trigger = { trait = greedy }
+		localisation_key = String_investments
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { trait = gardener }
+		localisation_key = String_garden
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { trait = architect }
+		localisation_key = String_building_plans
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = strategist
+				trait = duelist
+			}
+		}
+		localisation_key = String_sword_practice
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { is_learned_trigger = yes }
+		localisation_key = String_tome_collection
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { 
+			OR = {
+				num_of_friends = 1
+				trait = socializer
+			}
+		}
+		localisation_key = String_friends
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { num_of_lovers = 1 }
+		localisation_key = String_love
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { 
+			OR = {
+				has_character_modifier = pet_hunting_dog 
+				has_character_modifier = guide_dog 
+			}
+		}
+		localisation_key = String_dog
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		trigger = { has_character_modifier = pet_cat }
+		localisation_key = String_cat
+		weight_multiplier = { factor = 6 }
+	}
+	text = {
+		localisation_key = String_health
+		weight_multiplier = { 
+			factor = 1 #0.5
+			modifier = {
+				trait = craven
+				factor = 6
+			} 
+		}
+	}
+}
+
+
+#CHINA
+defined_text = {
+	name = GetLongChineseEmperorName
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetLongChineseEmperorName_string
+	}
+}
+
+defined_text = {
+	name = GetMediumChineseEmperorName
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetMediumChineseEmperorName_string
+	}
+}
+
+defined_text = {
+	name = GetShortChineseEmperorName
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetShortChineseEmperorName_string
+	}
+}
+
+defined_text = {
+	name = GetCouncillorLetterGreeting
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetCouncillorLetterGreeting_string
+	}
+}
+
+defined_text = {
+	name = GetRulerLetterGreeting
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetRulerLetterGreeting_string
+	}
+}
+
+defined_text = {
+	name = GetGovernorLetterGreeting
+	text = {
+		trigger = { always = yes }
+		localisation_key = GetGovernorLetterGreeting_string
+	}
+}
+
+defined_text = {
+	name = GetChineseLetterBlessing
+	text = {
+		trigger = { FROM = { has_job_title = job_chancellor } }
+		localisation_key = String_peace_and_unity
+	}
+	text = {
+		trigger = { FROM = { has_job_title = job_marshal } }
+		localisation_key = String_strength_and_vigor
+	}
+	text = {
+		trigger = { FROM = { has_job_title = job_treasurer } }
+		localisation_key = String_prospering_lands
+	}
+	text = {
+		trigger = { FROM = { has_job_title = job_spiritual } }
+		localisation_key = String_divine_guidance
+	}
+	text = {
+		trigger = { always = yes }
+		localisation_key = String_heavens_blessings
+	}
+	text = {
+		trigger = { always = yes }
+		localisation_key = String_good_health
+	}
+}
+
+defined_text = {
+	name = GetChineseComplimentAdjective
+	text = {
+		localisation_key = String_honored
+	}
+	text = {
+		trigger = { 
+			OR = {
+				trait = chaste
+				trait = celibate
+				AND = {
+					NOT = { num_of_lovers = 1 }
+					is_married = no
+					NOR = {
+						trait = seducer
+						trait = seductress
+						trait = lustful
+						has_focus = focus_seduction
+					}
+				}
+			}
+		}
+		localisation_key = String_chaste
+	}
+	text = {
+		trigger = {
+			OR = {
+				is_strong_trigger = yes
+				trait = fair
+			}
+		}
+		localisation_key = String_radiant
+	}
+	text = {
+		trigger = {
+			OR = {
+				is_learned_trigger = yes
+				tier = EMPEROR
+			}
+		}
+		localisation_key = String_illustrious
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = brave
+				trait = charitable
+				trait = honest
+				trait = diligent
+				trait = patient
+				trait = kind
+				trait = humble
+				trait = just
+			}
+			NOR = {
+				trait = drunkard
+				trait = deceitful
+				trait = cruel
+				trait = gluttonous
+				trait = slothful
+				trait = schemer
+				trait = wroth
+				is_any_kinslayer_trigger = yes
+				trait = cannibal_trait
+			}
+		}
+		localisation_key = String_honorable
+	}
+	text = {
+		trigger = {
+			OR = {
+				is_smart_trigger = yes
+				is_learned_trigger = yes
+				learning = 15
+			}
+		}
+		localisation_key = String_wise
+	}
+	text = {
+		trigger = {
+			OR = {
+				is_smart_trigger = yes
+				is_learned_trigger = yes
+				learning = 15
+			}
+		}
+		localisation_key = String_sage
+	}
+	text = {
+		trigger = {
+			OR = {
+				piety = 1000
+				trait = zealous
+				trait = content
+			}
+			NOT = { trait = cynical }
+		}
+		localisation_key = String_pious
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = just
+				AND = {
+					OR = {
+						trait = kind
+						trait = charitable
+					}
+					NOR = {
+						trait = arbitrary
+						trait = craven
+						trait = slothful
+						trait = content
+					}
+				}
+			}	
+		}
+		localisation_key = String_righteous
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = just
+				trait = kind
+				trait = charitable
+			}	
+			NOR = {
+				trait = wroth
+				trait = cruel
+				trait = impaler
+			}
+		}
+		localisation_key = String_benevolent
+	}
+	text = {
+		trigger = { trait = brave }
+		localisation_key = String_brave
+	}
+	text = {
+		trigger = { trait = honest }
+		localisation_key = String_sincere
+	}
+	text = {
+		trigger = {
+			is_female = yes
+			is_attractive_trigger = yes
+		}
+		localisation_key = String_lovely
+	}
+	text = {
+		trigger = {
+			OR = {
+				trait = fair
+				trait = gregarious
+				trait = socializer
+			}
+			has_unpleasant_trait_trigger = no
+			NOR = {
+				trait = ugly
+				trait = drunkard
+				trait = hedonist
+				trait = lustful
+			}
+		}
+		localisation_key = String_graceful
+	}
+	text = {
+		trigger = {
+			higher_tier_than = DUKE
+		}
+		localisation_key = String_great
+	}
+	text = {
+		trigger = {
+			higher_tier_than = DUKE
+		}
+		localisation_key = String_eminent
+	}
+	text = {
+		trigger = {
+			tier = EMPEROR
+		}
+		localisation_key = String_exalted
+	}
+	text = {
+		trigger = {
+			tier = EMPEROR
+		}
+		localisation_key = String_magnificent
+	}
+	text = {
+		trigger = {
+			is_offmap_ruler = yes
+		}
+		localisation_key = String_heavenly
+	}
+}
+
+defined_text = {
+	name = GetChineseOffmapTributaryPrestigeCost
+	text = {
+		trigger = { FROM = { tier = COUNT } }
+		localisation_key = String_offmap_cost_prestige_count
+	}
+	text = {
+		trigger = { FROM = { tier = DUKE } }
+		localisation_key = String_offmap_cost_prestige_duke
+	}
+	text = {
+		trigger = { FROM = { tier = KING is_nomadic = no } }
+		localisation_key = String_offmap_cost_prestige_king
+	}
+	text = {
+		trigger = { FROM = { tier = EMPEROR is_nomadic = no } }
+		localisation_key = String_offmap_cost_prestige_emperor
+	}
+	text = {
+		trigger = { FROM = { tier = KING is_nomadic = yes } }
+		localisation_key = String_offmap_cost_prestige_king_nomad
+	}
+	text = {
+		trigger = { FROM = { tier = EMPEROR is_nomadic = yes } }
+		localisation_key = String_offmap_cost_prestige_emperor_nomad
+	}
+}
+
+defined_text = { #being ordered context
+	name = GetChineseForceOpenDemand
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_tribute }
+		localisation_key = String_force_open_china_demands_tribute
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_trade_post }
+		localisation_key = String_force_open_china_demands_trade_post
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_wealth }
+		localisation_key = String_force_open_china_demands_wealth
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_eunuch }
+		localisation_key = String_force_open_china_demands_eunuch
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_concubine }
+		localisation_key = String_force_open_china_demands_concubine
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_return_chinese }
+		localisation_key = String_force_open_china_demands_chinese
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_backup }
+		localisation_key = String_force_open_china_demands_wealth #backup does reduced wealth
+	}
+}
+
+defined_text = { #third person context
+	name = GetChineseForceOpenDemandChina
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_tribute }
+		localisation_key = String_force_open_china_demands_tribute_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_trade_post }
+		localisation_key = String_force_open_china_demands_trade_post_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_wealth }
+		localisation_key = String_force_open_china_demands_wealth_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_eunuch }
+		localisation_key = String_force_open_china_demands_eunuch_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_concubine }
+		localisation_key = String_force_open_china_demands_concubine_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_return_chinese }
+		localisation_key = String_force_open_china_demands_chinese_china
+	}
+	text = { 
+		trigger = { has_character_flag = force_open_china_demands_backup }
+		localisation_key = String_force_open_china_demands_wealth_china #backup does reduced wealth
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+###NON-REUSABLE LOC KEYS###
+defined_text = {
+	name = GetCGMission
+	text = {
+		trigger = { has_character_flag = cg_diplomatic_visit }
+		localisation_key = GetCGMission_diplomatic_visit
+	}
+	text = {
+		trigger = { has_character_flag = cg_oversee_troops }
+		localisation_key = GetCGMission_oversee_troops
+	}
+	text = {
+		trigger = { has_character_flag = cg_study_military }
+		localisation_key = GetCGMission_study_military
+	}
+	text = {
+		trigger = { has_character_flag = cg_oversee_tax_collection }
+		localisation_key = GetCGMission_oversee_tax_collection
+	}
+	text = {
+		trigger = { has_character_flag = cg_trade }
+		localisation_key = GetCGMission_trade
+	}
+	text = {
+		trigger = { has_character_flag = cg_preaching }
+		localisation_key = GetCGMission_preaching
+	}
+	text = {
+		trigger = { has_character_flag = cg_study_theology }
+		localisation_key = GetCGMission_study_theology
+	}
+}
+
+defined_text = {
+	name = GetCGMissionOutcome
+	text = {
+		trigger = { has_character_flag = cg_diplomatic_visit }
+		localisation_key = GetCGMissionOutcome_diplomatic_visit
+	}
+	text = {
+		trigger = { has_character_flag = cg_oversee_troops }
+		localisation_key = GetCGMissionOutcome_oversee_troops
+	}
+	text = {
+		trigger = { has_character_flag = cg_study_military }
+		localisation_key = GetCGMissionOutcome_study_military
+	}
+	text = {
+		trigger = { has_character_flag = cg_oversee_tax_collection }
+		localisation_key = GetCGMissionOutcome_oversee_tax_collection
+	}
+	text = {
+		trigger = { has_character_flag = cg_trade }
+		localisation_key = GetCGMissionOutcome_trade
+	}
+	text = {
+		trigger = { has_character_flag = cg_preaching }
+		localisation_key = GetCGMissionOutcome_preaching
+	}
+	text = {
+		trigger = { has_character_flag = cg_study_theology }
+		localisation_key = GetCGMissionOutcome_study_theology
+	}
+}
+
+
+defined_text = {
+	name = GetHermeticInvention
+	text = {
+		trigger = { has_character_flag = war_invention }
+		localisation_key = String_warfare
+	}
+	text = {
+		trigger = { has_character_flag = prosperity_invention }
+		localisation_key = String_prosperity
+	}
+	text = {
+		trigger = { has_character_flag = knowledge_invention }
+		localisation_key = String_scholarship
+	}
+}
+
+defined_text = {
+	name = GetSocietyRankUpTooltip1
+
+	text = {
+		trigger = {  society_rank == 1 }
+		localisation_key = GetSocietyRankUpTooltip1_Standard_Rank1
+	}
+	text = {
+		trigger = { society_rank == 2 }
+		localisation_key = GetSocietyRankUpTooltip1_Standard_Rank2
+	}
+	text = {
+		trigger = { society_rank == 3 }
+		localisation_key = GetSocietyRankUpTooltip1_Standard_Rank3
+	}
+}
+
+defined_text = {
+	name = GetSocietyRankUpTooltip2
+
+	text = {
+		trigger = { 
+			NOR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = ""
+	}
+	text = {
+		trigger = { 
+			society_rank == 1
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = GetSocietyRankUpTooltip2_MOBuddhistJain_Rank1
+	}
+	text = {
+		trigger = { 
+			society_rank == 2
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = GetSocietyRankUpTooltip2_MOBuddhistJain_Rank2
+	}
+	text = {
+		trigger = { 
+			society_rank == 3
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = GetSocietyRankUpTooltip2_MOBuddhistJain_Rank3
+	}
+}
+
+# defined_text = {			###Vice requirements merged above
+	# name = GetSocietyRankUpTooltip3
+#
+	# text = {
+		# trigger = { 
+			# NOR = {
+				# society_member_of = monastic_order_jain
+				# society_member_of = monastic_order_buddhist
+			# }
+		# }
+		# localisation_key = ""
+	# }
+	# text = {
+		# trigger = {
+			# OR = {
+				# society_member_of = monastic_order_jain
+				# society_member_of = monastic_order_buddhist
+			# }
+		# }
+		# localisation_key = request_to_rank_up_within_society_no_vices
+	# }
+# }
+
+defined_text = {
+	name = GetSocietyRankUpTooltip4
+
+	text = {
+		trigger = { 
+			NOR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = ""
+	}
+	text = {
+		trigger = { 
+			society_rank == 1
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = request_to_rank_up_within_society_virtues1
+	}
+	text = {
+		trigger = { 
+			society_rank == 2
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = request_to_rank_up_within_society_virtues2
+	}
+	text = {
+		trigger = { 
+			society_rank == 3
+			OR = {
+				society_member_of = monastic_order_jain
+				society_member_of = monastic_order_buddhist
+			}
+		}
+		localisation_key = request_to_rank_up_within_society_virtues3
+	}
+}
+
+defined_text = {
+	name = GetDWRandomDemon
+	
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Mammon
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Beelzebub
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Abaddon
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Belphegor
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Asmodeus
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Leviathan
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Astaroth
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Belial
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Berith
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Lilith
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOT = { religion_group = zoroastrian_group }
+		}
+		localisation_key = String_Pythius
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Akoman
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Indar
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Nanghait
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Sawar
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Tauriz
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Zarizi
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Akatash
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Karash_Han
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Shyngay_Han
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Badysh_Han
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Kerey_Han
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Yabash_Han
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cold_ones
+		}
+		localisation_key = String_Baba_Yaga
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cold_ones
+		}
+		localisation_key = String_Berstuk
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cold_ones
+		}
+		localisation_key = String_the_Shishigas
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cold_ones
+		}
+		localisation_key = String_Polunocnica
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Bakasura
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Kirmira
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Jatasur
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Ravana
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Mahakali
+	}
+	text = {
+		trigger = {
+			society_member_of = the_trollcrafters
+		}
+		localisation_key = String_Angrboda
+	}
+	text = {
+		trigger = {
+			society_member_of = the_trollcrafters
+		}
+		localisation_key = String_Beli
+	}
+	text = {
+		trigger = {
+			society_member_of = the_trollcrafters
+		}
+		localisation_key = String_Fenrir
+	}
+	text = {
+		trigger = {
+			society_member_of = the_trollcrafters
+		}
+		localisation_key = String_Great_Loki
+	}
+}
+
+defined_text = {
+	name = GetDWPartyClothes
+	text = {
+		localisation_key = String_special_shoes
+	}
+	text = {
+		trigger = { is_female = no }
+		localisation_key = String_Russian_codpiece
+	}
+	text = {
+		trigger = {
+			OR = {
+				is_female = yes
+				trait = homosexual
+			}
+			religion_group = christian
+		}
+		localisation_key = String_Nuns_habit
+	}
+	text = {
+		trigger = {
+			religion_group = christian
+		}
+		localisation_key = String_Bishops_mitre
+	}
+	text = {
+		localisation_key = String_skin_mask
+	}
+	text = {
+		localisation_key = String_horned_helmet
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_pink_turban
+	}
+}
+
+defined_text = {
+	name = GetDWImplements
+	text = {
+		localisation_key = String_new_poisons
+	}
+	text = {
+		localisation_key = String_implements
+	}
+	text = {
+		localisation_key = String_Pear_of_Anguish
+	}
+	text = {
+		localisation_key = String_fav_thumbscrew
+	}
+	text = {
+		localisation_key = String_fav_garrotte
+	}
+}
+
+defined_text = {
+	name = GetDWSettlement
+	text = {
+		trigger = {
+			NOT = { society_member_of = the_plaguebringers }
+		}
+		localisation_key = String_town
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_camp
+	}
+}
+
+defined_text = {
+	name = GetDWDrug
+	text = {
+		localisation_key = String_Tears_of_Demeter
+	}
+	text = {
+		localisation_key = String_Fools_Honey
+	}
+	text = {
+		localisation_key = String_Blood_of_Jahi
+	}
+	text = {
+		localisation_key = String_Dreamers_Delight
+	}
+}
+
+defined_text = {
+	name = GetBitchBastard
+	text = {
+		trigger = {
+			is_female = yes
+		}
+		localisation_key = String_bitch
+	}
+	text = {
+		trigger = {
+			is_female = no
+		}
+		localisation_key = String_bastard
+	}
+}
+
+defined_text = {
+	name = GetDWBrethrenType
+	text = {
+		trigger = {
+			NOR = {
+				society_member_of = the_cold_ones
+				society_member_of = the_plaguebringers
+			}
+		}
+		localisation_key = String_Darkness
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cold_ones
+		}
+		localisation_key = String_Winter
+	}
+	text = {
+		trigger = {
+			society_member_of = the_plaguebringers
+		}
+		localisation_key = String_Disease
+	}
+}
+
+defined_text = {
+	name = GetDWDemonTerm
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			NOR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Demon_Prince
+	}
+	text = {
+		trigger = {
+			society_member_of = the_satanists
+			OR = {
+				religion_group = zoroastrian_group
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+			}
+		}
+		localisation_key = String_Greater_Daeva
+	}
+	
+	text = {
+		trigger = {
+			OR = {
+				society_member_of = the_cold_ones
+				society_member_of = the_plaguebringers
+			}
+		}
+		localisation_key = String_Greater_Demon
+	}
+	text = {
+		trigger = {
+			society_member_of = the_trollcrafters
+		}
+		localisation_key = String_Jotun_Lord
+	}
+	text = {
+		trigger = {
+			society_member_of = the_cult_of_kali
+		}
+		localisation_key = String_Rakshasa_Prince
+	}
+}
+
+defined_text = {
+	name = GetDWSacrifice
+
+	text = {
+		trigger = { has_character_flag = sacrifice_ruler }
+		localisation_key = String_powerful_ruler
+	}
+	text = {
+		trigger = { has_character_flag = sacrifice_holy_person }
+		localisation_key = String_servant_of_GetHighGodName
+	}
+	text = {
+		trigger = { has_character_flag = sacrifice_virgin }
+		localisation_key = String_virgin
+	}
+	text = {
+		trigger = { has_character_flag = sacrifice_dwarf }
+		localisation_key = String_dwarf
+	}
+}
+
+defined_text = {
+	name = GetWeaponsmithWeapon
+	
+	text = {
+		trigger = { has_character_flag = weapon_sword }
+		localisation_key = String_sword
+	}
+	text = {
+		trigger = { has_character_flag = weapon_scimitar }
+		localisation_key = String_scimitar
+	}
+	text = {
+		trigger = { has_character_flag = weapon_lance }
+		localisation_key = String_lance
+	}
+	text = {
+		trigger = { has_character_flag = weapon_axe }
+		localisation_key = String_axe
+	}
+	text = {
+		trigger = { has_character_flag = weapon_mace }
+		localisation_key = String_mace
+	}
+	text = {
+		trigger = { has_character_flag = weapon_bow }
+		localisation_key = String_bow
+	}	
+	text = {
+		trigger = { has_character_flag = armor_set }
+		localisation_key = String_set_of_armor
+	}	
+}
+
+defined_text = {
+	name = GetWeaponArmorSmith
+
+	text = {
+		trigger = { has_character_flag = weaponsmith }
+		localisation_key = String_weaponsmith
+	}
+	text = {
+		trigger = { has_character_flag = armorsmith }
+		localisation_key = String_armorsmith
+	}
+}
+
+defined_text = {
+	name = GetSunName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Sun_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Sun_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Sun_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Sun_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Sun_farsi
+	}
+}
+
+defined_text = {
+	name = GetMercuryName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mercury_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Mercury_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Mercury_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Mercury_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mercury_farsi
+	}
+}
+
+defined_text = {
+	name = GetVenusName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Venus_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Venus_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Venus_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Venus_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Venus_farsi
+	}
+}
+
+defined_text = {
+	name = GetEarthName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Earth_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Earth_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Earth_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Earth_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Earth_farsi
+	}
+}
+
+defined_text = {
+	name = GetMoonName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Moon_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Moon_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Moon_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Moon_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Moon_farsi
+	}
+}
+
+defined_text = {
+	name = GetMarsName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mars_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Mars_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Mars_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Mars_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mars_farsi
+	}
+}
+
+defined_text = {
+	name = GetJupiterName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Jupiter_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Jupiter_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Jupiter_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Jupiter_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Jupiter_farsi
+	}
+}
+
+defined_text = {
+	name = GetSaturnName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Saturn_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Saturn_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Saturn_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Saturn_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Saturn_farsi
+	}
+}
+
+defined_text = {
+	name = GetUranusName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Uranus_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Uranus_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Uranus_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Uranus_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Uranus_farsi
+	}
+}
+
+defined_text = {
+	name = GetNeptuneName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Neptune_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Neptune_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Neptune_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Neptune_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Neptune_farsi
+	}
+}
+
+defined_text = {
+	name = GetPlutoName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Pluto_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Pluto_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Pluto_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Pluto_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Pluto_farsi
+	}
+}
+
+defined_text = {
+	name = GetRandomPlanetName
+	
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mercury_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Mercury_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Mercury_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Mercury_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mercury_farsi
+	}
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Venus_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Venus_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Venus_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Venus_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Venus_farsi
+	}
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mars_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Mars_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Mars_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Mars_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Mars_farsi
+	}
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Jupiter_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Jupiter_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Jupiter_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Jupiter_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Jupiter_farsi
+	}
+	text = {
+		trigger = {
+			NOR = {
+				religion_group = muslim
+				culture = nahuatl
+				religion = hellenic_pagan
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Saturn_english
+	}
+	text = {
+		trigger = {
+			religion_group = muslim
+		}
+		localisation_key = String_Saturn_arabic
+	}
+	text = {
+		trigger = {
+			culture = nahuatl
+		}
+		localisation_key = String_Saturn_nahuatl
+	}
+	text = {
+		trigger = {
+			religion = hellenic_pagan
+		}
+		localisation_key = String_Saturn_hellenic
+	}
+	text = {
+		trigger = {
+			OR = {
+				religion = zun_pagan
+				religion = zun_pagan_reformed
+				religion_group = zoroastrian_group
+			}
+		}
+		localisation_key = String_Saturn_farsi
+	}
+}
+
+defined_text = {
+	name = GetHermeticsDestinedRole
+	
+	text = {
+		trigger = {
+			has_character_flag = destined_steward
+		}
+		localisation_key = String_steward
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_fighter
+		}
+		localisation_key = String_figther
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_diplomat
+		}
+		localisation_key = String_diplomat
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_schemer
+		}
+		localisation_key = String_schemer
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_scholar
+		}
+		localisation_key = String_scholar
+	}
+}
+
+defined_text = {
+	name = GetHermeticsDestinedExpertise
+	
+	text = {
+		trigger = {
+			has_character_flag = destined_steward
+		}
+		localisation_key = String_administration
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_fighter
+		}
+		localisation_key = String_battle
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_diplomat
+		}
+		localisation_key = String_diplomacy
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_schemer
+		}
+		localisation_key = String_intrigue
+	}
+	text = {
+		trigger = {
+			has_character_flag = destined_scholar
+		}
+		localisation_key = String_scholarship
+	}
+}
+
+
+defined_text = {
+	name = GetWesternZodiacSign
+	
+	text = {
+		trigger = {
+			is_born_under_Aries_trigger = yes
+		}
+		localisation_key = String_Aries
+	}
+	text = {
+		trigger = {
+			is_born_under_Taurus_trigger = yes
+		}
+		localisation_key = String_Taurus
+	}
+	text = {
+		trigger = {
+			is_born_under_Gemini_trigger = yes
+		}
+		localisation_key = String_Gemini
+	}
+	text = {
+		trigger = {
+			is_born_under_Cancer_trigger = yes
+		}
+		localisation_key = String_Cancer
+	}
+	text = {
+		trigger = {
+			is_born_under_Leo_trigger = yes
+		}
+		localisation_key = String_Leo
+	}
+	text = {
+		trigger = {
+			is_born_under_Virgo_trigger = yes
+		}
+		localisation_key = String_Virgo
+	}
+	text = {
+		trigger = {
+			is_born_under_Libra_trigger = yes
+		}
+		localisation_key = String_Libra
+	}
+	text = {
+		trigger = {
+			is_born_under_Scorpius_trigger = yes
+		}
+		localisation_key = String_Scorpius
+	}
+	text = {
+		trigger = {
+			is_born_under_Sagittarius_trigger = yes
+		}
+		localisation_key = String_Sagittarius
+	}
+	text = {
+		trigger = {
+			is_born_under_Capricorn_trigger = yes
+		}
+		localisation_key = String_Capricorn
+	}
+	text = {
+		trigger = {
+			is_born_under_Aquarius_trigger = yes
+		}
+		localisation_key = String_Aquarius
+	}
+	text = {
+		trigger = {
+			is_born_under_Pisces_trigger = yes
+		}
+		localisation_key = String_Pisces
+	}
+}
+
+defined_text = {
+	name = GetTheoryPaperQuality
+
+	text = {
+		trigger = { has_character_flag = theory_paper_simplistic }
+		localisation_key = String_a_rather_simplistic
+	}
+	text = {
+		trigger = { has_character_flag = theory_paper_average }
+		localisation_key = String_an_entirely_average
+	}
+	text = {
+		trigger = { has_character_flag = theory_paper_excellent }
+		localisation_key = String_an_excellent
+	}
+	text = {
+		trigger = { has_character_flag = theory_paper_revolutionary }
+		localisation_key = String_a_truly_revolutionary
+	}
+}
+
+defined_text = {
+	name = GetTheoryPaperQualityExpanded
+
+	text = {
+		trigger = { FROM = { has_character_flag = theory_paper_simplistic } }
+		localisation_key = String_simplistic
+	}
+	text = {
+		trigger = { FROM = { has_character_flag = theory_paper_average } }
+		localisation_key = String_average
+	}
+	text = {
+		trigger = { FROM = { has_character_flag = theory_paper_excellent } }
+		localisation_key = String_excellent
+	}
+	text = {
+		trigger = { FROM = { has_character_flag = theory_paper_revolutionary } }
+		localisation_key = String_revolutionary
+	}
+}
+
+#GetHermeticDebateSubject
+# Includes both definite and non-definite texts. Use as a self-contained object in your sentence. (We were debating [GetHermeticDebateSubject].)
+defined_text = {
+	name = GetHermeticDebateSubject
+
+	text = {
+		localisation_key = String_Universal_Theology
+	}
+	text = {
+		trigger = {
+			OR = { 
+				religion = catholic
+				religion = orthodox
+			}
+		}
+		localisation_key = String_origin_of_the_Trinity_before_Messiah
+	}
+	text = {
+		trigger = {
+			religion = jewish
+		}
+		localisation_key = String_Qabalah
+	}
+	text = {
+		localisation_key = String_unity_with_the_One
+	}
+	text = {
+		localisation_key = String_nature_of_Prima_materia
+	}
+	text = {
+		localisation_key = String_nature_of_the_Inner_and_the_Outer_cosmos
+	}
+	text = {
+		localisation_key = String_Prisca_theologia
+	}
+	text = {
+		localisation_key = String_esoteric_meaning_of_the_Caduceus
+	}
+	text = {
+		localisation_key = String_truth_inherent_to_Divine_Consciousness
+	}
+	text = {
+		localisation_key = String_interaction_of_the_soul_and_alchemy
+	}
+	text = {
+		localisation_key = String_very_definition_of_a_true_magnum_opus
+	}
+	text = {
+		weight_multiplier = { factor = 0.1 }
+		localisation_key = String_the_nature_of_the_Judgements_and_the_Bazaar
+	}
+	text = {
+		localisation_key = String_the_movement_of_celestial_bodies
+	}
+	text = {
+		localisation_key = String_the_laws_of_the_stars
+	}
+}
+
+
+defined_text = {
+	name = GetSillyDebateSubject
+
+	text = {
+		localisation_key = String_divinity_of_snails
+	}
+	text = {
+		localisation_key = String_snake_or_staff
+	}
+	text = {
+		localisation_key = String_why_gold_anyways
+	}
+	text = {
+		localisation_key = String_medicinal_application_of_alcohol
+	}
+	text = {
+		localisation_key = String_trinity_or_maybe_quaternity
+	}
+	text = {
+		localisation_key = String_emerald_tablet_kept_at_home
+	}
+	text = {
+		localisation_key = String_procedure_of_previous_debate
+	}
+	text = {
+		localisation_key = String_soul_leaving_body
+	}
+	text = {
+		localisation_key = String_kings_or_angels_higher_ranked
+	}
+	text = {
+		localisation_key = String_inferno_is_maybe_cool
+	}
+	text = {
+		weight_multiplier = { 
+			factor = 1 
+			modifier = {
+				factor = 0
+				NOT = { trait = immortal }
+			}
+		}
+		localisation_key = String_eternal_life_not_that_great
+	}
+	text = {
+		weight_multiplier = { factor = 0.4 }
+		localisation_key = String_top_ten_alchemists
+	}
+	text = {
+		localisation_key = String_that_feeling
+	}
+	text = {
+		weight_multiplier = { 
+			factor = 1
+			modifier = {
+				factor = 0.3
+				NOT = {
+					trait = gardener
+				} 
+			}
+		}
+		localisation_key = String_gardening_noble_work
+	}
+	text = {
+		weight_multiplier = { factor = 0.2 }
+		localisation_key = String_alchemists_make_better_lovers
+	}
+}
+
+defined_text = {
+	name = GetAssassinsDrugsTooltip
+
+	text = {
+		trigger = {
+			NOT = { has_character_modifier = withdrawal_symptoms }
+		}
+		localisation_key = String_assassins_drugs
+	}
+	text = {
+		trigger = {
+			has_character_modifier = withdrawal_symptoms
+		}
+		localisation_key = String_assassins_drugs_withdrawal
+	}
+}
+
+
+defined_text = {
+	name = GetOmenModifierName # (used exclusively in tooltip_info_omen_tt)
+
+	text = {
+		trigger = { has_character_modifier = good_battle_omen }
+		localisation_key = String_good_battle_omen
+	}
+	text = {
+		trigger = { has_character_modifier = good_relationship_omen }
+		localisation_key = String_good_relationship_omen
+	}
+	text = {
+		trigger = { has_character_modifier = good_power_omen }
+		localisation_key = String_good_power_omen
+	}
+	text = {
+		trigger = { has_character_modifier = bad_battle_omen }
+		localisation_key = String_bad_battle_omen
+	}
+	text = {
+		trigger = { has_character_modifier = bad_relationship_omen }
+		localisation_key = String_bad_relationship_omen
+	}
+	text = {
+		trigger = { has_character_modifier = bad_power_omen }
+		localisation_key = String_bad_power_omen
+	}
+}
+
+defined_text = {
+	name = GetOmenResultReaction #(used exclusively in tooltip_info_omen_tt)
+
+	text = {
+		trigger = { has_character_modifier = good_battle_omen has_character_flag = negative_event_flag }
+		localisation_key = String_good_battle_omen_bad_event
+	}
+	text = {
+		trigger = { has_character_modifier = good_relationship_omen has_character_flag = negative_event_flag }
+		localisation_key = String_good_relationship_omen_bad_event
+	}
+	text = {
+		trigger = { has_character_modifier = good_power_omen has_character_flag = negative_event_flag }
+		localisation_key = String_good_power_omen_bad_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_battle_omen has_character_flag = negative_event_flag }
+		localisation_key = String_bad_battle_omen_bad_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_relationship_omen has_character_flag = negative_event_flag }
+		localisation_key = String_bad_relationship_omen_bad_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_power_omen has_character_flag = negative_event_flag }
+		localisation_key = String_bad_power_omen_bad_event
+	}
+
+	text = {
+		trigger = { has_character_modifier = good_battle_omen has_character_flag = positive_event_flag }
+		localisation_key = String_good_battle_omen_good_event
+	}
+	text = {
+		trigger = { has_character_modifier = good_relationship_omen has_character_flag = positive_event_flag }
+		localisation_key = String_good_relationship_omen_good_event
+	}
+	text = {
+		trigger = { has_character_modifier = good_power_omen has_character_flag = positive_event_flag }
+		localisation_key = String_good_power_omen_good_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_battle_omen has_character_flag = positive_event_flag }
+		localisation_key = String_bad_battle_omen_good_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_relationship_omen has_character_flag = positive_event_flag }
+		localisation_key = String_bad_relationship_omen_good_event
+	}
+	text = {
+		trigger = { has_character_modifier = bad_power_omen has_character_flag = positive_event_flag }
+		localisation_key = String_bad_power_omen_good_event
+	}
+}
+
+defined_text = {
+	name = GetSeductionAstrologyPostScript # (used exclusively in WOL.404)
+
+	text = {
+		trigger = { has_character_flag = seduction_whats_your_zodiac }
+		localisation_key = String_our_signs_are_very_compatible
+	}
+	text = {
+		trigger = { NOT = { has_character_flag = seduction_whats_your_zodiac } }
+		localisation_key = String_empty_space
+	}
+}
+
+defined_text = {
+	name = GetSelectedIngredient_1
+	#herbs... 
+	text = {
+		localisation_key = String_Hibiscus
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb1
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Ginger_Root
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb2
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Mandrake
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb3
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Lemon_Grass
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Nettles
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Wormwood
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Valerian
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Violet
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Yarrow
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_herb9
+			}
+		}
+	}
+	#animal parts...
+	text = {
+		localisation_key = String_Gall_Bladder
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal1
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Kidney
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal2
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Eyeballs
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal3
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Cloven_hooves
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Antlers
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Snout
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Heart
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Liver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Intestines
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_animal9
+			}
+		}
+	}
+	#metals... (powder?)
+	text = {
+		localisation_key = String_Silver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic1
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Mercury
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic2
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Aqua_Regia
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic3
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Aqua_Fortis
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Brimstone
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Gold
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Copper
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Iron
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tin
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				artifact_type = ingredient_metal_exotic9
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetSelectedIngredient_2
+	#herbs... 
+	text = {
+		localisation_key = String_Hibiscus
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb1
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Ginger_Root
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb2
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Mandrake
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb3
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Lemon_Grass
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Nettles
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Wormwood
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Valerian
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Violet
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Yarrow
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_herb9
+			}
+		}
+	}
+	#animal parts...
+	text = {
+		localisation_key = String_Gall_Bladder
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal1
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Kidney
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal2
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Eyeballs
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal3
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Cloven_hooves
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Antlers
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Snout
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Heart
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Liver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Intestines
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_animal9
+			}
+		}
+	}
+	#metals... (powder?)
+	text = {
+		localisation_key = String_Silver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic1
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Mercury
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic2
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Aqua_Regia
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic3
+			}
+		}
+	}
+	text = { #(liquid)
+		localisation_key = String_Aqua_Fortis
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic4
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Brimstone
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic5
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Gold
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic6
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Copper
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic7
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Iron
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic8
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tin
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_2
+				artifact_type = ingredient_metal_exotic9
+			}
+		}
+	}
+}
+
+defined_text = {
+	name = GetSelectedIngredient_1_property
+	text = {
+		localisation_key = String_is_surprisingly_fragrant
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb1 #Hibiscus
+					artifact_type = ingredient_herb2 #Ginger Root
+					artifact_type = ingredient_herb4 #Lemongrass
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_herb8 #Violet
+					artifact_type = ingredient_herb9 #Yarrow
+				}
+			}			
+		}
+	}
+	text = {
+		localisation_key = String_are_surprisingly_fragrant
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb5 #Nettles
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_is_faintly_fragrant
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb1 #Hibiscus
+					artifact_type = ingredient_herb2 #Ginger Root
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_herb4 #Lemongrass
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_herb8 #Violet
+					artifact_type = ingredient_herb9 #Yarrow
+				}
+			}			
+		}
+	}
+	text = {
+		localisation_key = String_are_faintly_fragrant
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb5 #Nettles
+					artifact_type = ingredient_animal4 #Cloven Hooves
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_has_turned_to_dust
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb1 #Hibiscus
+					artifact_type = ingredient_herb2 #Ginger Root
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_herb4 #Lemongrass
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_herb8 #Violet
+					artifact_type = ingredient_herb9 #Yarrow
+					artifact_type = ingredient_metal_exotic5 #Brimstone
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_have_turned_to_dust
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb5 #Nettles
+					artifact_type = ingredient_animal4 #Cloven Hooves
+					artifact_type = ingredient_animal5 #Antlers
+					artifact_type = ingredient_animal3 #Eyeballs
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_reminds_me_of_them
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_animal6 #Snout
+				}
+			}
+			has_character_flag = dealing_with_inherited_ingredients
+		}
+	}
+	text = {
+		localisation_key = String_remind_me_of_them
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal4 #Cloven Hooves
+					artifact_type = ingredient_animal3 #Eyeballs
+				}
+			}
+			has_character_flag = dealing_with_inherited_ingredients
+		}
+	}
+	text = {
+		localisation_key = String_carries_an_unpleasant_smell
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb1 #Hibiscus
+					artifact_type = ingredient_herb2 #Ginger Root
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_herb8 #Violet
+					artifact_type = ingredient_herb9 #Yarrow
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_carry_an_unpleasant_smell
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs
+					artifact_type = ingredient_animal5 #Antlers
+					artifact_type = ingredient_animal9 #Intestines
+				}
+			}
+		}
+	}
+	
+	text = {
+		localisation_key = String_is_fantastically_shiny
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_metal_exotic1 #Silver
+					artifact_type = ingredient_metal_exotic2 #Mercury
+					artifact_type = ingredient_metal_exotic6 #Gold
+					artifact_type = ingredient_metal_exotic7 #Copper
+					artifact_type = ingredient_metal_exotic8 #Iron
+					artifact_type = ingredient_metal_exotic9 #Tin
+
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_are_fantastically_shiny
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs
+					artifact_type = ingredient_animal4 #Cloven Hooves
+					artifact_type = ingredient_animal5 #Antlers
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_should_not_be_touched
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal3 #Eyeballs
+					artifact_type = ingredient_animal4 #Cloven Hooves
+					artifact_type = ingredient_animal5 #Antlers
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_animal9 #Intestines
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_should_definitely_not_be_touched
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal3 #Eyeballs
+					artifact_type = ingredient_animal4 #Cloven Hooves
+					artifact_type = ingredient_animal5 #Antlers
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_animal9 #Intestines
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_would_make_most_people_uncomfortable
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_is_glass_jar
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_are_in_glass_jar
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_has_an_eerie_color
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_metal_exotic2 #Mercury
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_have_an_eerie_color
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb5 #Nettles			PLURAL
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_is_disgusting
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_are_disgusting
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_might_take_up_too_much_space
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				NOT = { artifact_type = ingredient_metal_exotic6 } #Gold
+			}
+			society_member_of = hermetics
+			has_character_flag = built_laboratory
+		}
+	}
+	text = {
+		localisation_key = String_does_not_send_desired_message
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_metal_exotic5 #Brimstone
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb3 #Mandrake
+				}
+			}
+			NOT = { society_member_of = hermetics }
+		}
+	}
+	text = {
+		localisation_key = String_do_not_send_desired_message
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+				}
+			}
+			NOT = { society_member_of = hermetics }
+		}
+	}
+	text = {
+		localisation_key = String_does_not_contribute_to_the_decor
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+
+					artifact_type = ingredient_herb1 #Hibiscus
+					artifact_type = ingredient_herb2 #Ginger Root
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_herb4 #Lemongrass
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb7 #Valerian
+					artifact_type = ingredient_herb8 #Violet
+					artifact_type = ingredient_herb9 #Yarrow
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_metal_exotic5 #Brimstone
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_herb3 #Mandrake
+					artifact_type = ingredient_metal_exotic7 #Copper
+					artifact_type = ingredient_metal_exotic8 #Iron
+					artifact_type = ingredient_metal_exotic9 #Tin
+				}
+			}
+			NOT = { society_member_of = hermetics }
+		}
+	}
+	text = {
+		localisation_key = String_do_not_contribute_to_the_decor
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb5 #Nettles			PLURAL
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+				}
+			}
+			NOT = { society_member_of = hermetics }
+		}
+	}
+	text = {
+		localisation_key = String_is_somewhat_pretty
+		trigger = {
+			OR = {
+				any_artifact = {
+					has_artifact_flag = selected_ingredient_1
+					OR = {
+						artifact_type = ingredient_herb1 #Hibiscus
+						artifact_type = ingredient_herb7 #Valerian
+						artifact_type = ingredient_herb8 #Violet
+						artifact_type = ingredient_herb9 #Yarrow
+						artifact_type = ingredient_metal_exotic6 #Gold
+					}
+				}
+				AND = {
+					society_member_of = hermetics
+					any_artifact = {
+						has_artifact_flag = selected_ingredient_1
+						OR = {
+							artifact_type = ingredient_metal_exotic3 #Aqua Regia
+							artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+						}
+					}
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_are_somewhat_pretty
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+				}
+			}
+			is_devil_worshiper_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = String_makes_me_shiver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+				}
+			}
+			is_devil_worshiper_trigger = no
+		}
+	}
+	text = {
+		localisation_key = String_make_me_shiver
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+				}
+			}
+			is_devil_worshiper_trigger = no
+		}
+	}
+	text = {
+		localisation_key = String_might_possess_hidden_uses
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+			}
+			society_member_of = hermetics
+		}
+	}
+	text = {
+		localisation_key = String_reeks
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_herb6 #Wormwood
+					artifact_type = ingredient_animal1 #Gallbladder
+					artifact_type = ingredient_animal2 #Kidney
+					artifact_type = ingredient_animal6 #Snout
+					artifact_type = ingredient_animal7 #Heart
+					artifact_type = ingredient_animal8 #Liver
+					artifact_type = ingredient_metal_exotic5 #Brimstone
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_reek
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+					artifact_type = ingredient_animal4 #Cloven Hooves   PLURAL
+					artifact_type = ingredient_animal5 #Antlers			PLURAL
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_glitters
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_metal_exotic1 #Silver
+					artifact_type = ingredient_metal_exotic2 #Mercury
+					artifact_type = ingredient_metal_exotic3 #Aqua Regia
+					artifact_type = ingredient_metal_exotic4 #Aqua Fortis
+					artifact_type = ingredient_metal_exotic6 #Gold
+					artifact_type = ingredient_metal_exotic7 #Copper
+					artifact_type = ingredient_metal_exotic8 #Iron
+					artifact_type = ingredient_metal_exotic9 #Tin
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_glitter
+		trigger = {
+			any_artifact = {
+				has_artifact_flag = selected_ingredient_1
+				OR = {
+					artifact_type = ingredient_animal9 #Intestines 		PLURAL
+					artifact_type = ingredient_animal3 #Eyeballs		PLURAL
+				}
+			}
+			is_devil_worshiper_trigger = yes
+		}
+	}
+}
+
+defined_text = {
+	name = GetDemonHuntersEventTitle #Work-around to have dynamic titles in an event - [USED ONLY IN MNM.7855]
+	
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_A
+		trigger = {
+			has_character_flag = DW_was_attacked_by_the_slayer
+		}
+	}
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_B
+		trigger = {
+			has_character_flag = DW_was_attacked_by_angry_villagers
+		}
+	}
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_C
+		trigger = {
+			has_character_flag = DW_was_attacked_by_demon_hunters
+		}
+	}	
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_D
+		trigger = {
+			has_character_flag = DW_was_attacked_by_lone_demon_hunter
+		}
+	}	
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_E
+		trigger = {
+			has_character_flag = DW_was_attacked_by_righteous_knights
+		}
+	}
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_A_again
+		trigger = {
+			has_character_flag = DW_was_attacked_by_the_slayer_again
+		}
+	}
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_B_again
+		trigger = {
+			has_character_flag = DW_was_attacked_by_angry_villagers_again
+		}
+	}
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_C_again
+		trigger = {
+			has_character_flag = DW_was_attacked_by_demon_hunters_again
+		}
+	}	
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_D_again
+		trigger = {
+			has_character_flag = DW_was_attacked_by_lone_demon_hunter_again
+		}
+	}	
+	text = {
+		localisation_key = EVTTITLE_MNM_7855_E_again
+		trigger = {
+			has_character_flag = DW_was_attacked_by_righteous_knights_again
+		}
+	}
+}
+
+
+defined_text = {
+	name = GetFriendEnjoyableQuirk #noun, singular
+	
+	text = {
+		localisation_key = String_way_with_words
+		trigger = {
+			OR = {
+				has_pleasant_trait_trigger = yes
+				diplomacy = 20
+			}
+		}
+	}
+	text = {
+		localisation_key = String_love_of_poetry
+		trigger = {
+			trait = poet
+		}
+	}
+	text = {
+		localisation_key = String_sharp_wit
+		trigger = {
+			is_smart_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = String_fighting_spirit
+		trigger = {
+			OR = {
+				is_maimed_trigger = yes
+				trait = brilliant_strategist
+			}
+		}
+	}
+	text = {
+		localisation_key = String_fascination_with_plants
+		trigger = {
+			trait = gardener
+		}
+	}	
+	text = {
+		localisation_key = String_morbid_sense_of_humor
+		trigger = {
+			is_evil_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = String_gentle_spirit
+		trigger = {
+			OR = {
+				is_benevolent_trigger = yes
+				is_dumb_trigger = yes	
+			}
+		}
+	}
+	text = {
+		localisation_key = String_what_makes_a_good_person
+	}
+	text = {
+		localisation_key = String_mischieveous_sense_of_humor
+	}
+	text = {
+		localisation_key = String_challenging_me
+	}	
+	text = {
+		localisation_key = String_infectious_smile
+		trigger = {
+			OR = {
+				has_lifestyle_diplomacy_trigger = yes
+				has_education_diplomacy_trigger = yes
+				has_attractive_trait_trigger = yes
+			}
+		}
+	}	
+	text = {
+		localisation_key = String_taste_in_music
+	}
+	text = {
+		localisation_key = String_appreciation_for_small_things
+		trigger = {
+			NOT = { trait = envious }
+		}
+	}
+	text = {
+		localisation_key = String_cracking_knuckles
+	}
+	text = {
+		localisation_key = String_optimistic_outlook_on_life
+		trigger = {
+			OR = {
+				has_pleasant_trait_trigger = yes
+				has_benevolent_trait_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_innocence
+		trigger = {
+			has_pleasant_trait_trigger = yes
+			NOT = { age = 40 }
+		}
+	}	
+	text = {
+		localisation_key = String_jaded_view_of_romance
+		trigger = {
+			OR = {
+				trait = cynical
+				trait = paranoid
+				is_evil_trigger = yes
+				has_unpleasant_personality_trigger = yes
+			}
+		}
+	}
+}
+
+### Empress or Emperor
+defined_text = {
+	name = GetEmpressEmperor
+
+	text = {
+		localisation_key = String_empress
+		trigger = { is_female = yes }
+	}
+	text = {
+		localisation_key = String_emperor
+		trigger = { is_female = no }
+	}
+}
+
+defined_text = {
+	name = GetEmpressEmperorCap
+
+	text = {
+		localisation_key = String_Empress
+		trigger = { is_female = yes }
+	}
+	text = {
+		localisation_key = String_Emperor
+		trigger = { is_female = no }
+	}
+}
+
+### Chinese flavor
+defined_text = {
+	name = GetChineseConvoTopic #Note that these are a little dry sounding and don't necessarily mention China by name. How to use in a sentence: 
+	# "As we discuss [adventurous_spirit.GetHerHis] travels to the [the_protector_general.Offmap.GetFullName] [adventurous_spirit.GetSheHe] speaks passionately about [adventurous_spirit.GetChineseConvoTopic]"
+	text = {
+		localisation_key = String_such_a_wealthy_realm
+		trigger = { china_is_fine_trigger = yes }
+	}
+	text = {
+		localisation_key = String_such_white_papers
+		trigger = { trait = poet }
+	}
+	text = {
+		localisation_key = String_so_full_of_life
+	}
+	text = {
+		localisation_key = String_the_street_jugglers
+	}
+	text = {
+		localisation_key = String_the_many_festivals
+	}
+	text = {
+		localisation_key = String_crowded_water_routes
+	}
+	text = {
+		localisation_key = String_artisan_potters
+	}
+	text = {
+		localisation_key = String_the_melody_of_Chinese_language
+		trigger = {
+			OR = {
+				has_character_modifier = multilingual
+				has_character_modifier = student_of_language
+				learning = 15
+			}
+		}
+	}
+	text = {
+		localisation_key = String_the_magnificent_architecture
+	}
+	text = {
+		localisation_key = String_a_religious_ceremony
+	}
+	text = {
+		localisation_key = String_a_pleasure_trip_on_a_lake
+	}
+	text = {
+		localisation_key = String_the_construction_of_Chinese_boats
+	}
+	text = {
+		localisation_key = String_the_Chinese_food
+	}
+	text = {
+		localisation_key = String_the_intricacies_of_Chinese_government
+	}
+	text = {
+		localisation_key = String_the_artistic_sensibility
+	}
+	text = {
+		localisation_key = String_friendly_to_outsiders
+		trigger = {
+			offmap_china = {
+				offmap_ruler = {
+					culture = mongol
+				}
+			}
+		}
+	}
+}
+
+defined_text = { # Must only be used after having visited China, as it talks in past tense and uses pronouns, eg: "When asked about [From.GetHerHis] travels, [From.GetSheHe] just mutters about [adventurous_spirit.GetNegativeChineseConvoTopic]."
+	name = GetNegativeChineseConvoTopic
+	text = {
+		localisation_key = String_too_much_people
+	}
+	text = {
+		localisation_key = String_firecrackers
+	}
+	text = {
+		localisation_key = String_bad_weather_and_language_barrier
+	}
+	#pirates?
+	##Disdain for traders
+}
+
+
+#GetRootMatchingPersonalityStreak
+defined_text = {
+	name = GetRootMatchingPersonalityStreak # Example: "I had a lovely conversation with myself the other day! I and [Root.GetFirstName] spoke for hours about [GetRootMatchingPersonalityStreak]."
+
+	#General personality groups
+	text = {
+		localisation_key = String_personality_benevolent
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_benevolent_trigger = yes
+			ROOT = { is_benevolent_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_evil
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_evil_trigger = yes
+			ROOT = { is_evil_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_pious
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_pious_trigger = yes
+			ROOT = { is_pious_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_impious
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_impious_trigger = yes
+			ROOT = { is_impious_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_pleasant
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_pleasant_personality_trigger = yes
+			ROOT = { has_pleasant_personality_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_unpleasant
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_unpleasant_personality_trigger = yes
+			ROOT = { has_unpleasant_personality_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_attractive
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = fair
+			ROOT = { trait = fair }
+		}
+	}
+	text = {
+		localisation_key = String_personality_unattractive
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = ugly
+			ROOT = { trait = ugly }
+		}
+	}
+	text = {
+		localisation_key = String_personality_smart_0
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_smart_trigger = yes
+			ROOT = { is_smart_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_smart_1
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_smart_trigger = yes
+			ROOT = { is_smart_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_smart_2
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_smart_trigger = yes
+			ROOT = { is_smart_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_dumb
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_dumb_trigger = yes
+			ROOT = { is_dumb_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_strong
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_strong_trigger = yes
+			ROOT = { is_strong_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_weak
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_weak_trigger = yes
+			ROOT = { is_weak_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_disease_symptom
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_symptom_trigger = yes
+			ROOT = { has_symptom_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_disease
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_disease_trigger = yes
+			ROOT = { has_disease_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_injury
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_injury_trigger = yes
+			ROOT = { has_injury_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_medium_disability
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_medium_disability_trigger = yes
+			ROOT = { has_medium_disability_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_stressed_depressed
+		weight_multiplier = {
+			factor = 10
+		}		
+		trigger = {
+			OR = {
+				trait = stressed
+				trait = depressed
+			}
+			ROOT = {
+				OR = {
+					trait = stressed
+					trait = depressed
+				}
+			}
+		}
+	}
+	## Education...
+	text = {
+		localisation_key = String_personality_top_education
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_top_tier_education_trait_trigger = yes
+			ROOT = { has_top_tier_education_trait_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_same_top_education
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_top_tier_education_trait_trigger = yes
+			ROOT = { has_top_tier_education_trait_trigger = yes }
+			OR = {
+				AND = {
+					has_education_diplomacy_trigger = yes
+					ROOT = { has_education_diplomacy_trigger = yes }
+				}
+				AND = {
+					has_education_martial_trigger = yes
+					ROOT = { has_education_martial_trigger = yes }
+				}
+				AND = {
+					has_education_stewardship_trigger = yes
+					ROOT = { has_education_stewardship_trigger = yes }
+				}
+				AND = {
+					has_education_intrigue_trigger = yes
+					ROOT = { has_education_intrigue_trigger = yes }
+				}
+				AND = {
+					has_education_learning_trigger = yes
+					ROOT = { has_education_learning_trigger = yes }
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_personality_education_diplomacy
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_education_diplomacy_trigger = yes
+			ROOT = { has_education_diplomacy_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_education_martial
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_education_martial_trigger = yes
+			ROOT = { has_education_martial_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_education_stewardship
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_education_stewardship_trigger = yes
+			ROOT = { has_education_stewardship_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_education_intrigue
+		weight_multiplier = {
+			factor = 10
+		}		
+		trigger = {
+			has_education_intrigue_trigger = yes
+			ROOT = { has_education_intrigue_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_education_learning
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_education_learning_trigger = yes
+			ROOT = { has_education_learning_trigger = yes }
+		}
+	}
+	### lifestyle/misc
+	text = {
+		localisation_key = String_personality_gardener
+		weight_multiplier = {
+			factor = 10
+		}		
+		trigger = {
+			trait = gardener
+			ROOT = { trait = gardener }
+		}
+	}
+	text = {
+		localisation_key = String_personality_hunter
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = hunter
+			ROOT = { trait = hunter }
+		}
+	}
+	text = {
+		localisation_key = String_personality_poet
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = poet
+			ROOT = { trait = poet }
+		}
+	}
+	text = {
+		localisation_key = String_personality_falconer
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = falconer
+			ROOT = { trait = falconer }
+		}
+	}
+	text = {
+		localisation_key = String_personality_mystic
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			trait = mystic
+			ROOT = { trait = mystic }
+		}
+	}
+	text = {
+		localisation_key = String_personality_learned
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			is_learned_trigger = yes
+			ROOT = { is_learned_trigger = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_council_member
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_job_title = yes
+			ROOT = { has_job_title = yes }
+		}
+	}
+	text = {
+		localisation_key = String_personality_council_member_same_liege
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			OR = {
+				has_job_title = yes
+				is_voter = yes
+			}
+			liege = {
+				OR = {
+					any_courtier = {
+						character = ROOT
+						prisoner = no
+						OR = {
+							has_job_title = yes
+							is_voter = yes
+						}
+					}
+					any_vassal = {
+						character = ROOT
+						prisoner = no
+						OR = {
+							has_job_title = yes
+							is_voter = yes
+						}
+					}
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_personality_old_and_wistful
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			age = 70
+			NOT = { trait = cynical }
+			ROOT = {
+				age = 70
+				NOT = { trait = cynical }
+			}
+		}
+	}
+	text = {
+		localisation_key = String_personality_young_cynics
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			NOT = { age = 20 }
+			ROOT = { NOT = { age = 20 } }
+			OR = { #at least one must be a cynic
+				trait = cynical
+				ROOT = { trait = cynical }
+			}
+		}
+	}
+	text = {
+		localisation_key = String_personality_same_society
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			same_society_as = ROOT
+		}
+	}
+	text = {
+		localisation_key = String_personality_same_culture
+		weight_multiplier = {
+			factor = 1
+		}
+		trigger = {			
+			culture_group = ROOT
+		}
+	}
+	text = {
+		localisation_key = String_personality_same_religion
+		weight_multiplier = {
+			factor = 1
+		}
+		trigger = {			
+			religion = ROOT
+		}
+	}
+	text = {
+		localisation_key = String_personality_landscape
+		weight_multiplier = {
+			factor = 1
+		}
+		trigger = {			
+			same_realm = ROOT
+		}
+	}
+	text = {
+		localisation_key = String_personality_artifacts
+		weight_multiplier = {
+			factor = 1
+		}
+		trigger = {			
+			any_artifact = {
+				count = 1
+			}
+			ROOT = {
+				any_artifact = {
+					count = 4
+				}
+			}
+		}
+	}	
+	#Same life style focus...
+	text = {
+		localisation_key = String_personality_focus_war
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {
+			has_focus = focus_war
+			ROOT = { has_focus = focus_war }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_hunting
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_hunting
+			ROOT = { has_focus = focus_hunting }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_seduction
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_seduction
+			ROOT = { has_focus = focus_seduction }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_intrigue
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_intrigue
+			ROOT = { has_focus = focus_intrigue }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_carousing
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_carousing
+			ROOT = { has_focus = focus_carousing }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_family
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_family
+			ROOT = { has_focus = focus_family }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_theology
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_theology
+			ROOT = { has_focus = focus_theology }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_scholarship
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_scholarship
+			ROOT = { has_focus = focus_scholarship }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_rulership
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_rulership
+			ROOT = { has_focus = focus_rulership }
+		}
+	}
+	text = {
+		localisation_key = String_personality_focus_business
+		weight_multiplier = {
+			factor = 10
+		}
+		trigger = {			
+			has_focus = focus_business
+			ROOT = { has_focus = focus_business }
+		}
+	}
+	###
+	fallback_text = {
+		localisation_key = String_personality_fallback
+	}
+}
+
+defined_text = {
+	name = GetMediumDisabilityDesc
+
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_one_legged
+		trigger = { trait = one_legged }
+	}
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_one_handed
+		trigger = { trait = one_handed }
+	}
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_one_eyed
+		trigger = {	trait = one_eyed }
+	}
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_clubfooted
+		trigger = { trait = clubfooted }
+	}
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_hunchback
+		trigger = { trait = hunchback }
+	}
+	text = {
+		localisation_key = String_GetMediumDisabilityDesc_dwarf
+		trigger = { trait = dwarf }
+	}
+}
+
+#For sending a Eunuch/Concubine to China...
+defined_text = {
+	name = GetImpressionOfTribute #gets general impression, depending on how much Grace you gained from it, essentially...
+
+	text = {
+		localisation_key = String_negative_impression_eunuch
+		trigger = { ROOT = { has_character_flag = sent_bad_tribute has_character_flag = sent_eunuch_tribute } }
+	}
+	text = {
+		localisation_key = String_decent_impression_eunuch
+		trigger = { ROOT = { has_character_flag = sent_decent_tribute has_character_flag = sent_eunuch_tribute } }
+	}
+	text = {
+		localisation_key = String_positive_impression_eunuch
+		trigger = {	ROOT = { has_character_flag = sent_great_tribute has_character_flag = sent_eunuch_tribute } }
+	}
+	text = {
+		localisation_key = String_negative_impression_concubine
+		trigger = { ROOT = { has_character_flag = sent_bad_tribute has_character_flag = sent_concubine_tribute } }
+	}
+	text = {
+		localisation_key = String_decent_impression_concubine
+		trigger = { ROOT = { has_character_flag = sent_decent_tribute has_character_flag = sent_concubine_tribute } }
+	}
+	text = {
+		localisation_key = String_positive_impression_concubine
+		trigger = {	ROOT = { has_character_flag = sent_great_tribute has_character_flag = sent_concubine_tribute } }
+	}
+	fallback_text = {
+		localisation_key = String_tribute_impression_fallback
+	}
+}
+
+#... Eunuch: If the Grace gain was very low...
+defined_text = {
+	name = GetNegativeImpressionOfEunuch
+
+	text = {
+		localisation_key = String_eunuch_is_dumb
+		trigger = { is_dumb_trigger = yes }
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 5
+				trait = dull
+			}
+			modifier = {
+				factor = 5
+				trait = slow
+			}
+			modifier = {
+				factor = 10
+				trait = imbecile
+			}
+		}
+	}
+	text = {
+		localisation_key = String_eunuch_is_ugly
+		trigger = {
+			is_unattractive_trigger = yes
+		}
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 10
+				trait = ugly
+			}
+			modifier = {
+				factor = 1.5
+				is_weak_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_eunuch_is_uncharming
+		trigger = {
+			is_adult = yes
+			OR = {
+				is_impious_trigger = yes
+				is_evil_trigger = yes
+				has_unpleasant_personality_trigger = yes
+			}
+		}
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 0.5
+				is_smart_trigger = yes
+			}
+			modifier = {
+				factor = 0.1
+				is_strong_trigger = yes
+			}
+			modifier = {
+				factor = 2
+				is_impious_trigger = yes
+				is_evil_trigger = yes
+			}
+			modifier = {
+				factor = 2
+				is_evil_trigger = yes
+				has_unpleasant_personality_trigger = yes
+			}
+			modifier = {
+				factor = 2
+				is_impious_trigger = yes
+				has_unpleasant_personality_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_eunuch_has_bad_education
+		trigger = {
+			has_bottom_tier_education_trait_trigger = yes
+		}
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 0.5
+				is_smart_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_eunuch_has_bad_stats_adult
+		trigger = {
+			is_adult = yes
+			NOT = { diplomacy = 6 }
+			NOT = { martial = 6 }
+			NOT = { stewardship = 6 }
+			NOT = { intrigue = 6 }
+			NOT = { learning = 6 }
+		}
+		weight_multiplier = {
+			factor = 10
+		}
+	}
+	text = {
+		localisation_key = String_eunuch_has_bad_stats_child
+		trigger = {
+			is_adult = no
+			NOT = { diplomacy = 2 }
+			NOT = { martial = 2 }
+			NOT = { stewardship = 2 }
+			NOT = { intrigue = 2 }
+			NOT = { learning = 2 }
+		}
+		weight_multiplier = {
+			factor = 10
+
+			modifier = {
+				factor = 0.5
+				is_smart_trigger = yes
+			}
+		}
+	}
+	fallback_text = {
+		localisation_key = String_eunuch_fallback_bad
+	}
+}
+
+#... Eunuch: If the Grace gain was OK...
+defined_text = {
+	name = GetDecentImpressionOfEunuch
+
+	text = {
+		localisation_key = String_eunuch_has_decent_education
+		trigger = { has_medium_education_trait_trigger = yes }
+	}
+	text = {
+		localisation_key = String_eunuch_is_close_relative_decent
+		trigger = {	is_close_relative = ROOT }
+	}
+	text = {
+		localisation_key = String_eunuch_has_decent_diplo
+		trigger = {	diplomacy = 10 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_decent_martial
+		trigger = {	martial = 10 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_decent_stewardship
+		trigger = {	stewardship = 10 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_decent_intrigue
+		trigger = {	intrigue = 10 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_decent_learning
+		trigger = {	learning = 10 }
+	}
+	text = {
+		localisation_key = String_eunuch_is_strong_decent
+		trigger = {	is_strong_trigger = yes}
+	}
+	text = {
+		localisation_key = String_eunuch_is_smart_decent
+		trigger = { is_smart_trigger = yes }
+	}
+	text = {
+		localisation_key = String_eunuch_is_attractive_decent
+		trigger = { trait = fair }
+	}
+	text = {
+		localisation_key = String_eunuch_is_architect_decent
+		trigger = { trait = architect }
+	}
+	text = {
+		localisation_key = String_eunuch_is_strategist_decent
+		trigger = { trait = strategist }
+	}
+	text = {
+		localisation_key = String_eunuch_is_scholar_decent
+		trigger = { trait = scholar }
+	}
+	text = {
+		localisation_key = String_eunuch_is_faqih_decent
+		trigger = { trait = faqih }
+	}
+	fallback_text = {
+		localisation_key = String_eunuch_fallback_decent
+	}
+}
+
+#... Eunuch: If the Grace gain was great...!
+defined_text = {
+	name = GetPositiveImpressionOfEunuch
+
+	text = {
+		localisation_key = String_eunuch_has_top_education
+		trigger = { has_top_tier_education_trait_trigger = yes }
+	}
+	text = {
+		localisation_key = String_eunuch_is_close_relative
+		trigger = {	is_close_relative = ROOT }
+	}
+	text = {
+		localisation_key = String_eunuch_has_high_diplo
+		trigger = {	diplomacy = 16 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_high_martial
+		trigger = {	martial = 16 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_high_stewardship
+		trigger = {	stewardship = 16 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_high_intrigue
+		trigger = {	intrigue = 16 }
+	}
+	text = {
+		localisation_key = String_eunuch_has_high_learning
+		trigger = {	learning = 16 }
+	}
+	text = {
+		localisation_key = String_eunuch_is_strong
+		trigger = {	is_strong_trigger = yes}
+	}
+	text = {
+		localisation_key = String_eunuch_is_smart
+		trigger = { is_smart_trigger = yes }
+	}
+	text = {
+		localisation_key = String_eunuch_is_attractive
+		trigger = { trait = fair }
+	}
+	text = {
+		localisation_key = String_eunuch_is_architect
+		trigger = { trait = architect }
+	}
+	text = {
+		localisation_key = String_eunuch_is_strategist
+		trigger = { trait = strategist }
+	}
+	text = {
+		localisation_key = String_eunuch_is_scholar
+		trigger = { trait = scholar }
+	}
+	text = {
+		localisation_key = String_eunuch_is_faqih
+		trigger = { trait = faqih }
+	}
+	fallback_text = {
+		localisation_key = String_eunuch_fallback_great
+	}
+}
+
+#... Concubine: If the Grace gain was very low...
+defined_text = {
+	name = GetNegativeImpressionOfConcubine
+
+	text = {
+		localisation_key = String_concubine_is_dumb
+		trigger = { is_dumb_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_is_ugly
+		trigger = {
+			is_unattractive_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = String_concubine_is_uncharming
+		trigger = {
+			is_adult = yes
+			OR = {
+				is_impious_trigger = yes
+				is_evil_trigger = yes
+				has_unpleasant_personality_trigger = yes
+			}
+		}
+	}
+	text = {
+		localisation_key = String_concubine_has_bad_education
+		trigger = {	has_bottom_tier_education_trait_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_has_bad_stats_adult
+		trigger = {
+			is_adult = yes
+			NOT = { diplomacy = 6 }
+			NOT = { martial = 6 }
+			NOT = { stewardship = 6 }
+			NOT = { intrigue = 6 }
+			NOT = { learning = 6 }
+		}
+	}
+	text = {
+		localisation_key = String_concubine_has_bad_stats_child
+		trigger = {
+			is_adult = no
+			NOT = { diplomacy = 2 }
+			NOT = { martial = 2 }
+			NOT = { stewardship = 2 }
+			NOT = { intrigue = 2 }
+			NOT = { learning = 2 }
+		}
+	}
+	fallback_text = {
+		localisation_key = String_concubine_fallback_bad
+	}
+}
+
+#... Concubine: If the Grace gain was OK...
+defined_text = {
+	name = GetDecentImpressionOfConcubine
+
+	text = {
+		localisation_key = String_concubine_has_decent_education
+		trigger = { has_medium_education_trait_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_is_close_relative_decent
+		trigger = {	is_close_relative = ROOT }
+	}
+	text = {
+		localisation_key = String_concubine_has_decent_diplo
+		trigger = {	diplomacy = 10 }
+	}
+	text = {
+		localisation_key = String_concubine_has_decent_martial
+		trigger = {	martial = 10 }
+	}
+	text = {
+		localisation_key = String_concubine_has_decent_stewardship
+		trigger = {	stewardship = 10 }
+	}
+	text = {
+		localisation_key = String_concubine_has_decent_intrigue
+		trigger = {	intrigue = 10 }
+	}
+	text = {
+		localisation_key = String_concubine_has_decent_learning
+		trigger = {	learning = 10 }
+	}
+	text = {
+		localisation_key = String_concubine_is_strong_decent
+		trigger = {	is_strong_trigger = yes}
+	}
+	text = {
+		localisation_key = String_concubine_is_smart_decent
+		trigger = { is_smart_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_is_attractive_decent
+		trigger = { trait = fair }
+	}
+	text = {
+		localisation_key = String_concubine_is_architect_decent
+		trigger = { trait = architect }
+	}
+	text = {
+		localisation_key = String_concubine_is_strategist_decent
+		trigger = { trait = strategist }
+	}
+	text = {
+		localisation_key = String_concubine_is_scholar_decent
+		trigger = { trait = scholar }
+	}
+	text = {
+		localisation_key = String_concubine_is_faqih_decent
+		trigger = { trait = faqih }
+	}
+	fallback_text = {
+		localisation_key = String_concubine_fallback_decent
+	}
+}
+
+#... Eunuch: If the Grace gain was great...!
+defined_text = {
+	name = GetPositiveImpressionOfConcubine
+
+	text = {
+		localisation_key = String_concubine_has_top_education
+		trigger = { has_top_tier_education_trait_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_is_close_relative
+		trigger = {	is_close_relative = ROOT }
+	}
+	text = {
+		localisation_key = String_concubine_has_high_diplo
+		trigger = {	diplomacy = 16 }
+	}
+	text = {
+		localisation_key = String_concubine_has_high_martial
+		trigger = {	martial = 16 }
+	}
+	text = {
+		localisation_key = String_concubine_has_high_stewardship
+		trigger = {	stewardship = 16 }
+	}
+	text = {
+		localisation_key = String_concubine_has_high_intrigue
+		trigger = {	intrigue = 16 }
+	}
+	text = {
+		localisation_key = String_concubine_has_high_learning
+		trigger = {	learning = 16 }
+	}
+	text = {
+		localisation_key = String_concubine_is_strong
+		trigger = {	is_strong_trigger = yes}
+	}
+	text = {
+		localisation_key = String_concubine_is_smart
+		trigger = { is_smart_trigger = yes }
+	}
+	text = {
+		localisation_key = String_concubine_is_attractive
+		trigger = { trait = fair }
+	}
+	text = {
+		localisation_key = String_concubine_is_architect
+		trigger = { trait = architect }
+	}
+	text = {
+		localisation_key = String_concubine_is_strategist
+		trigger = { trait = strategist }
+	}
+	text = {
+		localisation_key = String_concubine_is_scholar
+		trigger = { trait = scholar }
+	}
+	text = {
+		localisation_key = String_concubine_is_faqih
+		trigger = { trait = faqih }
+	}
+	fallback_text = {
+		localisation_key = String_concubine_fallback_great
+	}
+}
+
+# Description of Chinese activity when Isolationist
+defined_text = {
+	name = GetChinaIsolationPastime
+
+	text = {
+		localisation_key = String_Iso_Peach_Gardens
+	}
+	text = {
+		localisation_key = String_Iso_Giant_Mausoleum
+	}
+	text = {
+		localisation_key = String_Iso_Calligraphy
+	}
+	text = {
+		localisation_key = String_Iso_Lao_Tse
+	}
+	text = {
+		localisation_key = String_Iso_I_Ching
+	}
+	text = {
+		localisation_key = String_Iso_Great_Wall
+	}
+}
+
+# Description of the end of a Chinese Status
+defined_text = {
+	name = GetChinaPreviousStatusEnd
+
+	text = {
+		localisation_key = String_End_Stable
+		trigger = {
+			prev_status = china_stable
+		}
+	}
+	text = {
+		localisation_key = String_End_Unrest
+		trigger = {
+			prev_status = china_unrest
+			china_is_suffering_trigger = no
+		}
+	}
+	text = {
+		localisation_key = String_End_Unrest_Worsened
+		trigger = {
+			prev_status = china_unrest
+			china_is_suffering_trigger = yes
+		}
+	}
+	text = {
+		localisation_key = String_End_Famine
+		trigger = {
+			prev_status = china_famine
+		}
+	}
+	text = {
+		localisation_key = String_End_Plague
+		trigger = {
+			prev_status = china_plague
+		}
+	}
+	text = {
+		localisation_key = String_End_Mongols
+		trigger = {
+			prev_status = china_mongol_invasion
+		}
+	}
+	text = {
+		localisation_key = String_End_Jurchen
+		trigger = {
+			prev_status = china_jurchen_invasion
+		}
+	}
+	text = {
+		localisation_key = String_End_Civil_War
+		trigger = {
+			prev_status = china_civil_war
+			NOR = {
+				has_status = china_mongol_invasion
+				has_status = china_jurchen_invasion
+			}
+		}
+	}
+	text = {
+		localisation_key = String_End_Civil_War_to_Invasion
+		trigger = {
+			prev_status = china_civil_war
+			OR = {
+				has_status = china_mongol_invasion
+				has_status = china_jurchen_invasion
+			}
+		}
+	}
+	text = {
+		localisation_key = String_End_Golden_Age
+		trigger = {
+			prev_status = china_golden_age
+		}
+	}
+}
+
+# Names of important Chinese regions off-map
+defined_text = {
+	name = GetRandomChineseRegion
+
+	text = {
+		localisation_key = String_Luoyang
+	}
+	text = {
+		localisation_key = String_Chengdu
+	}
+	text = {
+		localisation_key = String_Datong
+	}
+	text = {
+		localisation_key = String_Guangzhou
+	}
+	text = {
+		localisation_key = String_Hangzhou
+	}
+	text = {
+		localisation_key = String_Kaifeng
+	}
+	text = {
+		localisation_key = String_Nanjing
+	}
+	text = {
+		localisation_key = String_Changan
+	}
+}
+
+# Names of typical Chinese troublemakers
+defined_text = {
+	name = GetRandomChineseFaction
+
+	text = {
+		localisation_key = String_Militant_Monks
+	}
+	text = {
+		localisation_key = String_Rogue_Mandarins
+	}
+	text = {
+		localisation_key = String_Ambitious_Eunuchs
+	}
+	text = {
+		localisation_key = String_Disgruntled_Officers
+	}
+}
+
+# Chinese focus
+defined_text = { #Read like: we are busy focusing on the [GetRandomChineseFocus] so can not open the Silk Road.
+	name = GetRandomChineseFocus
+	text = {
+		localisation_key = String_random_region
+		trigger = {		
+			OR = {
+				has_status = china_stable
+				has_status = china_golden_age
+			}
+		}
+	}
+	text = {
+		localisation_key = String_random_faction
+		trigger = { has_status = china_unrest }
+	}
+	text = {
+		localisation_key = String_current_invasion
+		trigger = {
+			OR = {
+				has_status = china_mongol_invasion
+				has_status = china_jurchen_invasion
+			}
+		}
+	}
+	text = {
+		localisation_key = String_current_status
+		trigger = {
+			OR = {
+				has_status = china_civil_war
+				has_status = china_famine
+				has_status = china_plague
+			}
+		}
+	}
+}
+
+# Gets the name of the current month
+defined_text = {
+	name = GetMonth
+	
+	text = {
+		trigger = {
+			month = 0
+			NOT = { month = 1 }
+		}
+		localisation_key = String_January
+	}
+	text = {
+		trigger = {
+			month = 1
+			NOT = { month = 2 }
+		}
+		localisation_key = String_February
+	}
+	text = {
+		trigger = {
+			month = 2
+			NOT = { month = 3 }
+		}
+		localisation_key = String_March
+	}
+	text = {
+		trigger = {
+			month = 3
+			NOT = { month = 4 }
+		}
+		localisation_key = String_April
+	}
+	text = {
+		trigger = {
+			month = 4
+			NOT = { month = 5 }
+		}
+		localisation_key = String_May
+	}
+	text = {
+		trigger = {
+			month = 5
+			NOT = { month = 6 }
+		}
+		localisation_key = String_June
+	}
+	text = {
+		trigger = {
+			month = 6
+			NOT = { month = 7 }
+		}
+		localisation_key = String_July
+	}
+	text = {
+		trigger = {
+			month = 7
+			NOT = { month = 8 }
+		}
+		localisation_key = String_August
+	}
+	text = {
+		trigger = {
+			month = 8
+			NOT = { month = 9 }
+		}
+		localisation_key = String_September
+	}
+	text = {
+		trigger = {
+			month = 9
+			NOT = { month = 10 }
+		}
+		localisation_key = String_October
+	}
+	text = {
+		trigger = {
+			month = 10
+			NOT = { month = 11 }
+		}
+		localisation_key = String_November
+	}
+	text = {
+		trigger = {
+			month = 11
+			NOT = { month = 12 }
+		}
+		localisation_key = String_December
+	}
+}
+
+
+
+# Gets the name of the Chinese refugee's specialty
+defined_text = {
+	name = GetChineseProfession
+	
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_administrator
+		}
+		localisation_key = String_administrator
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_master_engineer
+		}
+		localisation_key = String_engineer
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_strategist
+		}
+		localisation_key = String_strategist
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_doctor
+		}
+		localisation_key = String_physician
+	}
+	fallback_text = {
+		localisation_key = String_chinese_profession_fallback #Chinese refugee
+	}
+}
+
+# Gets the name of the Chinese courtier's invite reason (for when they die, mostly? Could be used elsewhere though.)
+defined_text = {
+	name = GetChineseCharacterRole
+	
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_administrator
+		}
+		localisation_key = String_administrator
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_master_engineer
+		}
+		localisation_key = String_engineer
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_siege_engineer
+		}
+		localisation_key = String_siege_engineer
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_strategist
+		}
+		localisation_key = String_strategist
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_doctor
+		}
+		localisation_key = String_physician
+	}
+	text = {
+		trigger = {
+			has_character_flag = is_chinese_imperial_marriage
+		}
+		localisation_key = String_chinese_royalty
+	}
+	fallback_text = {
+		localisation_key = String_chinese_character_role_fallback #courtier
+	}
+}
+
+
+defined_text = {
+	name = GetRegionalBigAnimal
+	
+	text = {
+		localisation_key = String_stag
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_europe_south
+					region = world_europe_west
+					region = world_asia_minor
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_bear
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_europe_north
+					region = world_europe_east
+					region = world_steppe
+					region = world_himalayas					
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_tiger
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_india
+					region = world_persia
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_lion
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_middle_east
+					region = world_africa
+				}
+			}
+		}
+	}
+	fallback_text = {
+		localisation_key = String_animal_fallback #Beast
+	}
+}
+defined_text = {
+	name = GetRegionalBigAnimalCap
+	
+	text = {
+		localisation_key = String_Stag
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_europe_south
+					region = world_europe_west
+					region = world_asia_minor
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Bear
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_europe_north
+					region = world_europe_east
+					region = world_steppe
+					region = world_himalayas					
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Tiger
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_india
+					region = world_persia
+				}
+			}
+		}
+	}
+	text = {
+		localisation_key = String_Lion
+		trigger = {
+			capital_scope = {
+				OR = {
+					region = world_middle_east
+					region = world_africa
+				}
+			}
+		}
+	}
+	fallback_text = {
+		localisation_key = String_animalCap_fallback #Beast
+	}
+}
+
+defined_text = {
+	name = GetPublicOpinionOfWork
+	
+	#Vices
+	text = {
+		trigger = {
+			trait = lustful
+		}
+		weight_multiplier = {
+			factor = 10
+			modifier = {
+				factor = 10
+				OR = {
+					has_focus = focus_seduction
+					has_lifestyle_diplomacy_trigger = yes				
+				}
+			}
+		}
+		localisation_key = String_suggestive
+	}
+	text = {
+		trigger = {
+			trait = gluttonous
+		}
+		weight_multiplier = {
+			factor = 10
+			modifier = {
+				factor = 10
+				has_focus = focus_carousing
+			}
+		}
+		localisation_key = String_over_indulgent
+	}
+	text = {
+		trigger = {
+			trait = greedy
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_lackluster
+	}
+	text = {
+		trigger = {
+			trait = slothful
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_stale
+	}
+	text = {
+		trigger = {
+			trait = wroth
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_indignant
+	}
+	text = {
+		trigger = {
+			trait = envious
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_belligerent
+	}
+	text = {
+		trigger = {
+			trait = proud
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_pompous
+	}
+	#Virtues
+	text = {
+		trigger = {
+			trait = chaste
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_dull
+	}
+	text = {
+		trigger = {
+			trait = temperate
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_uninspired
+	}
+	text = {
+		trigger = {
+			trait = charitable
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_too_accommodating
+	}
+	text = {
+		trigger = {
+			trait = diligent
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_too_detailed
+	}
+	text = {
+		trigger = {
+			trait = patient
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_dreary
+	}
+	text = {
+		trigger = {
+			trait = kind
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_ceremonious
+	}
+	text = {
+		trigger = {
+			trait = humble
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_soft_spoken
+	}
+
+	#Other
+	text = {
+		trigger = {
+			trait = deceitful
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_confusing
+	}
+	text = {
+		trigger = {
+			trait = honest
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_misguided
+	}
+	text = {
+		trigger = {
+			trait = craven
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_timid
+	}
+	text = {
+		trigger = {
+			trait = brave
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_bold
+	}
+	text = {
+		trigger = {
+			trait = shy
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_trite
+	}
+	text = {
+		trigger = {
+			trait = gregarious
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_entertaining
+	}
+	text = {
+		trigger = {
+			trait = ambitious
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_ambitious
+	}
+	text = {
+		trigger = {
+			trait = content
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_mundane
+	}
+	text = {
+		trigger = {
+			trait = arbitrary
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_random
+	}
+	text = {
+		trigger = {
+			trait = just
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_dispassionate
+	}
+	text = {
+		trigger = {
+			trait = cynical
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_contemptuous
+	}
+	text = {
+		trigger = {
+			trait = zealous
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_uptight
+	}
+	text = {
+		trigger = {
+			trait = paranoid
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_paranoid
+	}
+	text = {
+		trigger = {
+			trait = trusting
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_naive
+	}
+	text = {
+		trigger = {
+			trait = cruel
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_callous
+	}
+	text = {
+		trigger = {
+			trait = erudite
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_pedantic
+	}
+	text = {
+		trigger = {
+			trait = stubborn
+		}
+		weight_multiplier = { factor = 10 }
+		localisation_key = String_narrow_minded
+	}
+
+	#scripted groups (should be prioritized)
+	text = {
+		trigger = {
+			is_benevolent_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_too_much
+	}
+	text = {
+		trigger = {
+			is_evil_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_petty
+	}
+	text = {
+		trigger = {
+			is_pious_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_judgmental
+	}
+	text = {
+		trigger = {
+			is_impious_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_spiteful
+	}
+	text = {
+		trigger = {
+			is_smart_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_convoluted
+	}
+	text = {
+		trigger = {
+			is_dumb_trigger = yes
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_amusing
+	}
+	
+	fallback_text = {
+		localisation_key = String_opinion_fallback #decent
+	}
+}
+
+defined_text = { #NOTE: only used when writing a book (due to event_target:new_book)!
+	name = GetExpectationOfWork
+	
+	#fast writers...
+	text = {
+		trigger = {
+			has_character_flag = currently_working_on_a_book
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 1825 } } #five years
+			event_target:new_book = {
+				quality = 1
+				NOT = { quality = 2 }
+			}
+		}
+		localisation_key = String_disappointed_in_my_scribes #wrote lowest quality book, fast
+	}
+	text = {
+		trigger = {
+			has_character_flag = currently_working_on_a_book
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 1825 } } #five years
+			event_target:new_book = {
+				quality = 2
+    			NOT = { quality = 3 }
+			}
+		}
+		localisation_key = String_pleased_with_scribes #wrote medium quality book, fast
+	}
+	text = {
+		trigger = {
+			has_character_flag = currently_working_on_a_book
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 1825 } } #five years
+			event_target:new_book = {
+				OR = {
+					quality = 3
+					quality = 4
+				}
+			}
+		}
+		localisation_key = String_in_awe_of_my_scribes_as_well_as_myself #wrote great quality book, fast
+	}
+
+	#slower writers...
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 1825 } #five years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 3650 } } #ten years
+			event_target:new_book = {
+				quality = 1
+				NOT = { quality = 2 }
+			}
+		}
+		localisation_key = String_disappointed_in_myself_and_my_scribes #wrote lowest quality book, medium speed
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 1825 } #five years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 3650 } } #ten years
+			event_target:new_book = {
+				quality = 2
+    			NOT = { quality = 3 }
+			}
+		}
+		localisation_key = String_not_disappointed_in_my_scribes #wrote medium quality book, medium speed
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 1825 } #five years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 3650 } } #ten years
+			event_target:new_book = {
+				OR = {
+					quality = 3
+					quality = 4
+				}
+			}
+		}
+		localisation_key = String_grateful_to_my_scribes #wrote great quality book, medium speed
+	}
+
+	#the slowest of all...
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 3650 } #ten years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 7300 } } #twenty years
+			event_target:new_book = {
+				quality = 1
+				NOT = { quality = 2 }
+			}
+		}
+		localisation_key = String_having_trouble_understanding_what_I_could_have_done_differently #wrote lowest quality book, over a long time
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 3650 } #ten years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 7300 } } #twenty years
+			event_target:new_book = {
+				quality = 2
+    			NOT = { quality = 3 }
+			}
+		}
+		localisation_key = String_almost_surprised_it_was_finally_finished #wrote medium quality book, over a long time
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 3650 } #ten years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 7300 } } #twenty years
+			event_target:new_book = {
+				OR = {
+					quality = 3
+					quality = 4
+				}
+			}
+		}
+		localisation_key = String_filled_with_a_sense_of_well_deserved_pride #wrote great quality book, over a long time
+	}
+	fallback_text = {
+		localisation_key = String_expectation_of_work_fallback #decent
+	}
+}
+defined_text = {
+	name = GetTimeItTookToWriteBook
+	
+	text = {
+		trigger = {
+			has_character_flag = currently_working_on_a_book
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 1095 } } #three years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_most_of_my_spare_time
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 1095 } #three years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 2920 } } #eight years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_several_years
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 2920 } #eight years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 4380 } } #twelve years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_years_and_years
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 4380 } #twelve years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 6570 } } #18 years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_over_a_decade
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 6570 } #18 years
+			NOT = { had_character_flag = { flag = currently_working_on_a_book days = 7300 } } #20 years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_the_better_part_of_a_lifetime
+	}
+	text = {
+		trigger = {
+			had_character_flag = { flag = currently_working_on_a_book days = 7300 } #20 years
+		}
+		weight_multiplier = { factor = 100 }
+		localisation_key = String_most_of_my_life
+	}
+	fallback_text = {
+		localisation_key = String_what_feels_like_forever
+	}
+}
+
+
+defined_text = {
+	name = GetRaidCD
+	
+	text = {
+		trigger = {
+			has_character_modifier = china_raid_grace_cd
+		}
+		localisation_key = string_raid_cd
+	}
+}
+
+defined_text = {
+	name = GetNegotiateCD
+	
+	text = {
+		trigger = {
+			has_character_modifier = adventurer_negotiate_cd
+		}
+		localisation_key = string_negotiate_cd
+	}
+}
+
+defined_text = {
+	name = GetSmithCD
+	
+	text = {
+		trigger = {
+			has_character_modifier = employ_a_smith_cd
+		}
+		localisation_key = string_smith_cd
+	}
+}
+
+
+defined_text = {
+	name = GetArtifactDescriptor #has to be in an artifact scope!!
+	text = {
+		localisation_key = String_valuable
+		trigger = {
+			has_artifact_flag = chinese
+			has_artifact_flag = book
+		}
+	}
+	text = {
+		localisation_key = String_dangerous
+		trigger = {
+			has_artifact_flag = chinese
+			has_artifact_flag = combat_weapon
+		}
+	}
+	text = {
+		localisation_key = String_beautiful
+		trigger = {
+			has_artifact_flag = chinese
+			has_artifact_flag = decor
+		}
+	}
+	fallback_text = {
+		localisation_key = String_lovely
+	}
+}
+
+defined_text = {
+	name = GetMourningBehavior
+	text = {
+		localisation_key = String_still_distraught
+		trigger = {
+			trait = depressed
+			OR = {
+				AND = {
+					is_married = no
+					has_character_flag = mourner_is_spouse
+				}
+				has_character_flag = mourner_is_grown_child
+			}
+		}
+	}
+	text = {
+		localisation_key = String_still_dont_understand
+		trigger = {
+			has_character_flag = mourner_is_small_child
+		}
+	}
+	text = {
+		localisation_key = String_done_my_best_to_accept_it
+		trigger = {
+			NOT = { trait = depressed }
+			is_evil_trigger = no
+			has_character_flag = mourner_is_spouse
+			OR = {
+				is_married = yes
+				trait = content
+			}
+		}
+	}
+	text = {
+		localisation_key = String_hate_to_admit_it
+		trigger = {
+			has_benevolent_trait_trigger = no		
+			has_character_flag = mourner_is_spouse
+		}
+	}
+	text = {
+		localisation_key = String_feel_angry
+		trigger = {
+			trait = wroth
+			OR = {
+				has_character_flag = mourner_is_spouse
+				has_character_flag = mourner_is_grown_child			
+			}
+		}
+	}
+	text = {
+		localisation_key = String_i_miss_them
+		trigger = {
+			has_character_flag = mourner_is_grown_child			
+		}
+	}
+	text = {
+		localisation_key = String_i_see_them_everywhere
+		trigger = {
+			trait = lunatic
+		}
+	}
+	fallback_text = {
+		localisation_key = String_still_saddens_me
+	}
+}
+
+defined_text = {
+	name = GetCapitalLocation
+	text = {
+		localisation_key = String_capital_name
+		trigger = {
+			is_feudal = yes
+		}
+	}
+	text = {
+		localisation_key = String_capital_location
+		trigger = {
+			NOT = { is_feudal = yes }
+		}
+	}
+	fallback_text = {
+		localisation_key = String_capital_province
+	}
+}
+defined_text = {
+	name = GetWeaponName
+
+	text = {
+		localisation_key = string_culture_weapon
+	}
+
+	text = {
+		localisation_key = string_dynasty_weapon
+	}
+
+	text = {
+		localisation_key = string_silver_weapon
+	}
+
+	text = {
+		localisation_key = string_first_name_weapon
+	}
+
+	text = {
+		localisation_key = string_royal_title_weapon
+	}
+}
+
+defined_text = {
+	name = GetPositiveWeaponAttribute
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_royal
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_majestic
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_magnificent
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_impervious
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_illustrious
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_august
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_regal
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_renowned
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_imposing
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_noble
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_exalted
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_elegant
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_supreme
+	}
+}
+
+defined_text = {
+	name = GetWeaponType
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_sword
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_blade
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_falchion
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_2
+		}
+		localisation_key = string_longsword
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_2
+		}
+		localisation_key = string_greatsword
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = scimitar_tier_1
+				has_character_flag = scimitar_tier_2
+			}
+		}
+		localisation_key = string_scimitar
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = scimitar_tier_1
+				has_character_flag = scimitar_tier_2
+			}
+		}
+		localisation_key = string_shamshir
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = lance_tier_1
+				has_character_flag = lance_tier_2
+			}		
+		}
+		localisation_key = string_lance
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = lance_tier_1
+				has_character_flag = lance_tier_2
+			}
+		}
+		localisation_key = string_spear
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_axe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_battleaxe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_waraxe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = mace_tier_1
+				has_character_flag = mace_tier_2
+			}
+		}
+		localisation_key = string_mace
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = mace_tier_1
+				has_character_flag = mace_tier_2
+			}
+		}
+		localisation_key = string_warhammer
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_1
+		}
+		localisation_key = string_bow
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_2
+		}
+		localisation_key = string_longbow
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_2
+		}
+		localisation_key = string_compositebow
+	}
+}
+
+defined_text = {
+	name = GetWeaponName
+
+	text = {
+		localisation_key = string_culture_weapon
+	}
+
+	text = {
+		localisation_key = string_dynasty_weapon
+	}
+
+	text = {
+		localisation_key = string_silver_weapon
+	}
+
+	text = {
+		localisation_key = string_first_name_weapon
+	}
+
+	text = {
+		localisation_key = string_royal_title_weapon
+	}
+}
+
+defined_text = {
+	name = GetPositiveWeaponAttribute
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_royal
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_majestic
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_magnificent
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_impervious
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_illustrious
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_august
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_regal
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_renowned
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_imposing
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_noble
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_exalted
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_elegant
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = sword_tier_2
+				has_character_flag = scimitar_tier_2
+				has_character_flag = lance_tier_2
+				has_character_flag = axe_tier_2
+				has_character_flag = mace_tier_2
+				has_character_flag = bow_tier_2
+			}
+		}
+		localisation_key = string_supreme
+	}
+}
+
+defined_text = {
+	name = GetWeaponType
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_sword
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_blade
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_1
+		}
+		localisation_key = string_falchion
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_2
+		}
+		localisation_key = string_longsword
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = sword_tier_2
+		}
+		localisation_key = string_greatsword
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = scimitar_tier_1
+				has_character_flag = scimitar_tier_2
+			}
+		}
+		localisation_key = string_scimitar
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = scimitar_tier_1
+				has_character_flag = scimitar_tier_2
+			}
+		}
+		localisation_key = string_shamshir
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = lance_tier_1
+				has_character_flag = lance_tier_2
+			}		
+		}
+		localisation_key = string_lance
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = lance_tier_1
+				has_character_flag = lance_tier_2
+			}
+		}
+		localisation_key = string_spear
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_axe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_battleaxe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = axe_tier_1
+				has_character_flag = axe_tier_2
+			}
+		}
+		localisation_key = string_waraxe
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = mace_tier_1
+				has_character_flag = mace_tier_2
+			}
+		}
+		localisation_key = string_mace
+	}
+
+	text = {
+		trigger = {
+			OR = {
+				has_character_flag = mace_tier_1
+				has_character_flag = mace_tier_2
+			}
+		}
+		localisation_key = string_warhammer
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_1
+		}
+		localisation_key = string_bow
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_2
+		}
+		localisation_key = string_longbow
+	}
+
+	text = {
+		trigger = {
+			has_character_flag = bow_tier_2
+		}
+		localisation_key = string_compositebow
+	}
+}
+
+defined_text = {
+	name = GetSeaQueenKing
+
+	text = {
+		trigger = {
+			is_female = yes
+		}
+		localisation_key = string_seaqueen
+	}
+
+	text = {
+		trigger = {
+			is_female = no
+		}
+		localisation_key = string_seaking
+	}
+}

--- a/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
+++ b/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
@@ -2398,6 +2398,54 @@ defined_text = {
 defined_text = {
 	name = GetHouseOfWorship # Returns a suitable name for the house of worship of your religion (WIP)
 
+	use_first_valid = yes
+
+	# Note that currently all religions have Temples, even the Church of the Eternal Flame (who do in canon have Temple Guards).
+	# If that changes in the future then we need to update this as well.
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = northern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = evil_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = elven_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = dwarven_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = halfling_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = gnomish_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = dryad_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = southern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = eastern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = wilderness_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = northern_religions }
+	}
 	fallback_text = {
 		localisation_key = string_Temple
 	}
@@ -2406,6 +2454,54 @@ defined_text = {
 defined_text = {
 	name = GetHouseOfWorshipCap # Returns a suitable name for the house of worship of your religion (WIP)
 
+	use_first_valid = yes
+
+	# Note that currently all religions have Temples, even the Church of the Eternal Flame (who do in canon have Temple Guards).
+	# If that changes in the future then we need to update this as well.
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = northern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = evil_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = elven_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = dwarven_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = halfling_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = gnomish_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = dryad_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = southern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = eastern_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = wilderness_religions }
+	}
+	text = {
+		localisation_key = string_Temple
+		trigger = { religion_group = northern_religions }
+	}
 	fallback_text = {
 		localisation_key = string_Temple
 	}
@@ -2414,6 +2510,54 @@ defined_text = {
 defined_text = {
 	name = GetReligiousRite # Returns a suitable name for a common rite in the character's religion
 
+	use_first_valid = yes
+
+	# Note that currently all religions use prayers (as opposed to mass, mantras, worship, and so on).
+	# If that changes in the future then we need to update this as well.
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = northern_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = evil_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = elven_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = dwarven_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = halfling_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = gnomish_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = dryad_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = southern_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = eastern_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = wilderness_religions }
+	}
+	text = {
+		localisation_key = String_prayer
+		trigger = { religion_group = northern_religions }
+	}
 	fallback_text = {
 		localisation_key = String_prayer
 	}

--- a/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
+++ b/MOD/Witcher/localisation/customizable_localisation/00_customizable_localisation.txt
@@ -2442,10 +2442,6 @@ defined_text = {
 		localisation_key = string_Temple
 		trigger = { religion_group = wilderness_religions }
 	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion_group = northern_religions }
-	}
 	fallback_text = {
 		localisation_key = string_Temple
 	}
@@ -2498,10 +2494,6 @@ defined_text = {
 		localisation_key = string_Temple
 		trigger = { religion_group = wilderness_religions }
 	}
-	text = {
-		localisation_key = string_Temple
-		trigger = { religion_group = northern_religions }
-	}
 	fallback_text = {
 		localisation_key = string_Temple
 	}
@@ -2553,10 +2545,6 @@ defined_text = {
 	text = {
 		localisation_key = String_prayer
 		trigger = { religion_group = wilderness_religions }
-	}
-	text = {
-		localisation_key = String_prayer
-		trigger = { religion_group = northern_religions }
 	}
 	fallback_text = {
 		localisation_key = String_prayer


### PR DESCRIPTION
Fixes issue #86 

With the suggestion on how to debug I was able to verify my changes, and for example confirm that it was selecting the text entry for the correct religion group and that it wasn't just selecting the first entry or the fallback entry.

I've verified this in a saved game that I've loaded.  I've also confirmed that ruins are unaffected -- they still show up as their name just as before (ex.: "Ruins of Loc Muinne").

Note however that all holdings were called (and are still called) Temples, regardless of religion.  I'm referring for example to "Temple of Barwice" (controlled by the Church of the Eternal Flame) in the county of Novigrad, or the "Temple of Shaentmorc", and so on.  I have not changed that behavior, and in fact to match that I set the religious building names within that holding as "Temple".  So the "Temple of Barwice" has "Temple Walls" and "Temple Town", etc...